### PR TITLE
Archive imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,7 +128,6 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 [[package]]
 name = "arga-core"
 version = "0.1.0"
-source = "git+https://github.com/ARGA-Genomes/arga-backend.git#91733b9ca7275b6d5e1eda659f17bd1e95398203"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -201,6 +215,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,7 +292,7 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "strsim 0.10.0",
  "termcolor",
  "textwrap",
@@ -567,6 +602,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +653,18 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "fnv"
@@ -672,6 +725,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -742,7 +801,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -826,6 +895,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,7 +933,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -984,6 +1064,7 @@ version = "0.1.0"
 dependencies = [
  "arga-core",
  "bigdecimal",
+ "brotli",
  "chrono",
  "clap 4.5.16",
  "csv",
@@ -995,7 +1076,9 @@ dependencies = [
  "memmap2 0.9.4",
  "rayon",
  "serde",
+ "tar",
  "thiserror",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1294,6 +1377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1548,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1645,40 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap 2.5.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1845,6 +1982,26 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # for local development
 arga-core = { path = "../backend/core" }
 bigdecimal = { version = "0.4.5", features = ["serde"] }
+brotli = "6.0.0"
 chrono = { version = "0.4.38", features = ["serde"] }
 
 clap = { version = "4.5.9", features = ["derive"] }
@@ -20,7 +21,9 @@ memchr = "2.7.4"
 memmap2 = "0.9.4"
 rayon = "1.10.0"
 serde = { version = "1.0.204", features = ["derive"] }
+tar = "0.4.41"
 thiserror = "1.0.63"
+toml = "0.8.19"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 uuid = { version = "1.10.0", features = ["serde", "v4"] }

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -84,7 +84,7 @@ impl Archive {
             match import_type {
                 ImportType::Unknown => info!("Unknown type, skipping"),
                 ImportType::Taxa => loggers::taxa::import(stream, &meta.dataset)?,
-                ImportType::TaxonomicActs => todo!(),
+                ImportType::TaxonomicActs => loggers::taxonomic_acts::import(stream, &meta.dataset)?,
                 ImportType::NomenclaturalActs => todo!(),
                 ImportType::Collections => todo!(),
                 ImportType::Sequences => todo!(),

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -6,7 +6,7 @@ use tracing::info;
 
 use crate::errors::{Error, ParseError};
 use crate::readers::meta::Meta;
-use crate::{loggers, ProgressStream};
+use crate::{loggers, upsert_meta, ProgressStream};
 
 
 #[derive(Debug)]
@@ -66,7 +66,8 @@ impl Archive {
 
     pub fn import(&self) -> Result<(), Error> {
         let meta = self.meta()?;
-        info!(name = meta.dataset.short_name, version = meta.dataset.version, "Found dataset");
+        info!(name = meta.dataset.short_name, version = meta.dataset.version, "Upserting dataset");
+        upsert_meta(meta.clone())?;
 
         let file = File::open(&self.path)?;
         let mut archive = tar::Archive::new(file);

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,0 +1,95 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+
+use tracing::info;
+
+use crate::errors::{Error, ParseError};
+use crate::readers::meta::Meta;
+use crate::{loggers, ProgressStream};
+
+
+#[derive(Debug)]
+pub enum ImportType {
+    Unknown,
+    Taxa,
+    TaxonomicActs,
+    NomenclaturalActs,
+    Collections,
+    Sequences,
+}
+
+impl From<String> for ImportType {
+    fn from(value: String) -> Self {
+        use ImportType::*;
+
+        match value.as_str() {
+            "taxa.csv.br" => Taxa,
+            "taxonomic_acts.csv.br" => TaxonomicActs,
+            "nomenclatural_acts.csv.br" => NomenclaturalActs,
+            "collections.csv.br" => Collections,
+            "sequences.csv.br" => Sequences,
+            _ => Unknown,
+        }
+    }
+}
+
+
+pub struct Archive {
+    path: PathBuf,
+}
+
+impl Archive {
+    pub fn new(path: PathBuf) -> Archive {
+        Archive { path }
+    }
+
+    pub fn meta(&self) -> Result<Meta, Error> {
+        let file = File::open(&self.path)?;
+        let mut archive = tar::Archive::new(file);
+        let meta_filename = String::from("meta.toml");
+
+        for entry in archive.entries_with_seek()? {
+            let mut file = entry?;
+            let path = file.header().path()?.to_str().unwrap_or_default().to_string();
+
+            if path == meta_filename {
+                let mut s = String::new();
+                file.read_to_string(&mut s)?;
+                let meta = toml::from_str(&s).map_err(|err| Error::Parsing(ParseError::Toml(err)))?;
+                return Ok(meta);
+            }
+        }
+
+        Err(Error::Parsing(ParseError::FileNotFound(meta_filename)))
+    }
+
+    pub fn import(&self) -> Result<(), Error> {
+        let meta = self.meta()?;
+        info!(name = meta.dataset.short_name, version = meta.dataset.version, "Found dataset");
+
+        let file = File::open(&self.path)?;
+        let mut archive = tar::Archive::new(file);
+
+        for entry in archive.entries_with_seek()? {
+            let entry = entry?;
+            let path = entry.header().path()?.to_str().unwrap_or_default().to_string();
+            let size = entry.header().size()?;
+            let import_type = ImportType::from(path.clone());
+
+            info!(path, size, ?import_type);
+            let stream = ProgressStream::new(entry, size as usize);
+
+            match import_type {
+                ImportType::Unknown => info!("Unknown type, skipping"),
+                ImportType::Taxa => loggers::taxa::import(stream, &meta.dataset)?,
+                ImportType::TaxonomicActs => todo!(),
+                ImportType::NomenclaturalActs => todo!(),
+                ImportType::Collections => todo!(),
+                ImportType::Sequences => todo!(),
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/database.rs
+++ b/src/database.rs
@@ -69,6 +69,7 @@ fn find_dataset_id(dataset_id: &str) -> Result<Uuid, Error> {
 pub fn create_dataset_version(dataset_id: &str, version: &str, created_at: &str) -> Result<DatasetVersion, Error> {
     use schema::dataset_versions;
 
+    info!(dataset_id, version, created_at, "Creating dataset version");
     let pool = get_pool()?;
     let mut conn = pool.get()?;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,4 +23,10 @@ pub enum ParseError {
 
     #[error(transparent)]
     DateFormat(#[from] chrono::ParseError),
+
+    #[error("invalid archive: could not find {0}")]
+    FileNotFound(String),
+
+    #[error(transparent)]
+    Toml(#[from] toml::de::Error),
 }

--- a/src/loggers/mod.rs
+++ b/src/loggers/mod.rs
@@ -1,16 +1,20 @@
-mod collections;
-mod names;
-mod nomenclatural_acts;
-mod sequences;
-mod taxa;
-mod taxonomic_acts;
+pub mod collections;
+pub mod names;
+pub mod nomenclatural_acts;
+pub mod sequences;
+pub mod taxa;
+pub mod taxonomic_acts;
 
 
+use std::fs::File;
+use std::io::Read;
+use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 
 use arga_core::crdt::DataFrameOperation;
 use arga_core::models::LogOperation;
 pub use collections::Collections;
+use indicatif::ProgressBarIter;
 pub use nomenclatural_acts::NomenclaturalActs;
 use rayon::prelude::*;
 pub use sequences::Sequences;
@@ -19,12 +23,49 @@ pub use taxa::Taxa;
 pub use taxonomic_acts::TaxonomicActs;
 use uuid::Uuid;
 
-use crate::database::{get_pool, FrameLoader};
+use crate::database::{create_dataset_version, get_pool, FrameLoader};
 use crate::errors::Error;
 use crate::operations::{distinct_changes, Framer};
 use crate::readers::csv::{CsvReader, IntoFrame};
-use crate::readers::OperationLoader;
+use crate::readers::{meta, OperationLoader};
 use crate::utils::FrameImportBars;
+
+
+pub trait FrameProgress {
+    fn bars(&self) -> FrameImportBars;
+}
+
+impl<S: Read + FrameProgress> FrameProgress for brotli::Decompressor<S> {
+    fn bars(&self) -> FrameImportBars {
+        self.get_ref().bars()
+    }
+}
+
+
+pub struct ProgressStream<S: Read> {
+    stream: ProgressBarIter<S>,
+    bars: FrameImportBars,
+}
+
+impl<S: Read> ProgressStream<S> {
+    pub fn new(stream: S, total_bytes: usize) -> ProgressStream<S> {
+        let bars = FrameImportBars::new(total_bytes);
+        let stream = bars.bytes.wrap_read(stream);
+        ProgressStream { stream, bars }
+    }
+}
+
+impl<S: Read> FrameProgress for ProgressStream<S> {
+    fn bars(&self) -> FrameImportBars {
+        self.bars.clone()
+    }
+}
+
+impl<S: Read> Read for ProgressStream<S> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.stream.read(buf)
+    }
+}
 
 
 /// A parallel CSV framer and importer.
@@ -36,22 +77,71 @@ use crate::utils::FrameImportBars;
 ///
 /// The Reader (<R>) must implement the IntoFrame trait and be deserializable from a CSV file.
 /// The Operation (<Op>) must implement the OperationLoader trait
-pub fn import_csv_as_logs<R, Op>(path: &PathBuf, dataset_version_id: &Uuid) -> Result<(), Error>
+pub fn import_csv_as_logs<T, Op>(path: &PathBuf, dataset_version_id: &Uuid) -> Result<(), Error>
 where
     Op: Sync,
-    R: DeserializeOwned + IntoFrame,
-    R::Atom: Default + Clone + ToString + PartialEq,
+    T: DeserializeOwned + IntoFrame,
+    T::Atom: Default + Clone + ToString + PartialEq,
     FrameLoader<Op>: OperationLoader + Clone,
     <FrameLoader<Op> as OperationLoader>::Operation:
-        LogOperation<R::Atom> + From<DataFrameOperation<R::Atom>> + Clone + Sync,
+        LogOperation<T::Atom> + From<DataFrameOperation<T::Atom>> + Clone + Sync,
 {
+    let file = File::open(path)?;
+    let size = file.metadata()?.size();
+    let stream = ProgressStream::new(file, size as usize);
+    import_csv_from_stream::<T, Op, _>(stream, dataset_version_id)?;
+    Ok(())
+}
+
+
+/// Imports a CSV stream that has been compressed.
+///
+/// This will use the brotli decompressor before passing the stream on to `import_csv_from_stream` where
+/// it will proceed as if it was an extracted CSV file
+pub fn import_compressed_csv_stream<S, T, Op>(stream: S, dataset: &meta::Dataset) -> Result<(), Error>
+where
+    S: Read + FrameProgress,
+    Op: Sync,
+    T: DeserializeOwned + IntoFrame,
+    T::Atom: Default + Clone + ToString + PartialEq,
+    FrameLoader<Op>: OperationLoader + Clone,
+    <FrameLoader<Op> as OperationLoader>::Operation:
+        LogOperation<T::Atom> + From<DataFrameOperation<T::Atom>> + Clone + Sync,
+{
+    let input = brotli::Decompressor::new(stream, 4096);
+    let dataset_version = create_dataset_version(&dataset.id, &dataset.version, &dataset.published_at.to_string())?;
+    import_csv_from_stream::<T, Op, _>(input, &dataset_version.id)?;
+    Ok(())
+}
+
+/// A parallel CSV framer and importer.
+///
+/// This caters for the general path of importing operations logs from a CSV file by treating each
+/// row as a single frame and bulk upserting the distinct changes. It also displays a progress bar.
+/// Because its a generic function that relies on implemented traits it has to be called as a
+/// turbo fish function, ie. `import_csv_as_logs::<Record, TaxonOperation>(&path, &dataset_version_id)`.
+///
+/// The Record (<T>) must implement the IntoFrame trait and be deserializable from a CSV file.
+/// The Operation (<Op>) must implement the OperationLoader trait
+/// The Reader (<R>) only needs to implement std::io::Read
+pub fn import_csv_from_stream<T, Op, R>(reader: R, dataset_version_id: &Uuid) -> Result<(), Error>
+where
+    R: Read + FrameProgress,
+    Op: Sync,
+    T: DeserializeOwned + IntoFrame,
+    T::Atom: Default + Clone + ToString + PartialEq,
+    FrameLoader<Op>: OperationLoader + Clone,
+    <FrameLoader<Op> as OperationLoader>::Operation:
+        LogOperation<T::Atom> + From<DataFrameOperation<T::Atom>> + Clone + Sync,
+{
+    let bars = reader.bars();
+
     // we need a few components to fully import operation logs. the first is a CSV file reader
     // which parses each row and converts it into a frame. the second is a framer which allows
     // us to conveniently get chunks of frames from the reader and sets us up for easy parallelization.
     // and the third is the frame loader which allows us to query the database to deduplicate and
     // pull out unique operations, as well as upsert the new operations.
-    let reader: CsvReader<R> = CsvReader::from_path(path.clone(), dataset_version_id.clone())?;
-    let bars = FrameImportBars::new(reader.total_rows);
+    let reader = CsvReader::<T, R>::from_reader(reader, *dataset_version_id)?;
     let framer = Framer::new(reader);
     let loader = FrameLoader::<Op>::new(get_pool()?);
 
@@ -77,7 +167,7 @@ where
             Ok::<(), Error>(())
         })?;
 
-        bars.total.inc(total_frames as u64);
+        bars.frames.inc(total_frames as u64);
     }
 
     bars.finish();

--- a/src/loggers/taxa.rs
+++ b/src/loggers/taxa.rs
@@ -1,3 +1,4 @@
+use std::io::Read;
 use std::path::PathBuf;
 
 use arga_core::crdt::lww::Map;
@@ -21,10 +22,9 @@ use crate::database::{
     MaterializedView,
 };
 use crate::errors::Error;
-use crate::frame_push_opt;
 use crate::operations::group_operations;
 use crate::readers::csv::IntoFrame;
-use crate::readers::OperationLoader;
+use crate::readers::{meta, OperationLoader};
 use crate::utils::{
     new_progress_bar,
     new_spinner,
@@ -32,6 +32,7 @@ use crate::utils::{
     taxonomic_status_from_str,
     titleize_first_word,
 };
+use crate::{frame_push_opt, import_compressed_csv_stream, FrameProgress};
 
 type TaxonFrame = DataFrame<TaxonAtom>;
 
@@ -168,6 +169,10 @@ pub struct Taxon {
     last_updated: Option<String>,
 }
 
+
+pub fn import<S: Read + FrameProgress>(stream: S, dataset: &meta::Dataset) -> Result<(), Error> {
+    import_compressed_csv_stream::<S, Record, TaxonOperation>(stream, dataset)
+}
 
 pub struct Taxa {
     pub path: PathBuf,

--- a/src/loggers/taxonomic_acts.rs
+++ b/src/loggers/taxonomic_acts.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::io::Read;
 use std::path::PathBuf;
 
 use arga_core::crdt::lww::Map;
@@ -21,11 +22,11 @@ use uuid::Uuid;
 
 use crate::database::{dataset_lookup, get_pool, taxon_lookup, FrameLoader};
 use crate::errors::Error;
-use crate::frame_push_opt;
 use crate::operations::group_operations;
 use crate::readers::csv::IntoFrame;
-use crate::readers::OperationLoader;
+use crate::readers::{meta, OperationLoader};
 use crate::utils::{date_time_from_str_opt, new_progress_bar, new_spinner, taxonomic_status_from_str};
+use crate::{frame_push_opt, import_compressed_csv_stream, FrameProgress};
 
 type TaxonomicActFrame = DataFrame<TaxonomicActAtom>;
 
@@ -151,6 +152,12 @@ pub struct TaxonomicAct {
     publication_date: Option<String>,
     source_url: Option<String>,
 }
+
+
+pub fn import<S: Read + FrameProgress>(stream: S, dataset: &meta::Dataset) -> Result<(), Error> {
+    import_compressed_csv_stream::<S, Record, TaxonomicActOperation>(stream, dataset)
+}
+
 
 pub struct TaxonomicActs {
     pub path: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod archive;
 mod database;
 mod errors;
 mod loggers;
@@ -22,9 +23,12 @@ struct Cli {
 
 #[derive(clap::Subcommand)]
 pub enum Commands {
+    /// Process and import an ARGA dataset archive as operation logs
+    Import { path: PathBuf },
+
     /// Process and import a csv as operation logs
     #[command(subcommand)]
-    Import(ImportCommand),
+    ImportFile(ImportCommand),
 
     /// Reduce operation logs and output as an ARGA CSV
     #[command(subcommand)]
@@ -123,7 +127,11 @@ fn main() -> Result<(), Error> {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::Import(cmd) => match cmd {
+        Commands::Import { path } => {
+            let archive = archive::Archive::new(path.clone());
+            archive.import()?;
+        }
+        Commands::ImportFile(cmd) => match cmd {
             ImportCommand::Taxa {
                 dataset_id,
                 version,
@@ -137,7 +145,6 @@ fn main() -> Result<(), Error> {
                 };
                 taxa.import()?
             }
-
             ImportCommand::TaxonomicActs {
                 dataset_id,
                 version,

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -89,7 +89,7 @@ where
             // because merging uses the last-write-wins map for reduction it still returns
             // the existing operations. because this is a distinct operation iterator we
             // want to remove the existing ops from the merged set
-            let changes = merged.into_iter().filter(|op| !ids.contains(&op.id())).collect();
+            let changes = merged.into_iter().filter(|op| !ids.contains(op.id())).collect();
             Ok(changes)
         }
     }
@@ -134,7 +134,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         let frames: Vec<Result<DataFrame<R::Atom>, Error>> = self.stream.by_ref().take(self.chunk_size).collect();
-        if frames.len() > 0 {
+        if !frames.is_empty() {
             Some(Frames::new(frames))
         }
         else {

--- a/src/readers/meta.rs
+++ b/src/readers/meta.rs
@@ -1,0 +1,43 @@
+use serde::Deserialize;
+
+
+#[derive(Debug, Deserialize)]
+pub struct Meta {
+    pub dataset: Dataset,
+    pub changelog: Changelog,
+    pub attribution: Attribution,
+    pub collection: Collection,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Dataset {
+    pub id: String,
+    pub name: String,
+    pub short_name: String,
+    pub version: String,
+    /// RFC 3339
+    pub published_at: toml::value::Datetime,
+    pub url: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Changelog {
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Attribution {
+    pub citation: String,
+    pub source_url: String,
+    pub license: String,
+    pub rights_holder: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Collection {
+    pub name: String,
+    pub author: String,
+    pub license: String,
+    pub rights_holder: String,
+    pub access_rights: String,
+}

--- a/src/readers/meta.rs
+++ b/src/readers/meta.rs
@@ -1,7 +1,10 @@
+use arga_core::models;
+use chrono::Utc;
 use serde::Deserialize;
+use uuid::Uuid;
 
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Meta {
     pub dataset: Dataset,
     pub changelog: Changelog,
@@ -9,7 +12,7 @@ pub struct Meta {
     pub collection: Collection,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Dataset {
     pub id: String,
     pub name: String,
@@ -20,12 +23,12 @@ pub struct Dataset {
     pub url: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Changelog {
     pub notes: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Attribution {
     pub citation: String,
     pub source_url: String,
@@ -33,11 +36,44 @@ pub struct Attribution {
     pub rights_holder: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Collection {
     pub name: String,
     pub author: String,
     pub license: String,
     pub rights_holder: String,
     pub access_rights: String,
+}
+
+
+impl From<Meta> for models::Source {
+    fn from(meta: Meta) -> Self {
+        models::Source {
+            id: Uuid::new_v4(),
+            name: meta.collection.name,
+            author: meta.collection.author,
+            rights_holder: meta.collection.rights_holder,
+            access_rights: meta.collection.access_rights,
+            license: meta.collection.license,
+        }
+    }
+}
+
+impl From<Meta> for models::Dataset {
+    fn from(meta: Meta) -> Self {
+        models::Dataset {
+            id: Uuid::new_v4(),
+            source_id: Uuid::default(),
+            global_id: meta.dataset.id,
+            name: meta.dataset.name,
+            short_name: Some(meta.dataset.short_name),
+            description: None,
+            url: Some(meta.dataset.url),
+            citation: Some(meta.attribution.citation),
+            license: Some(meta.attribution.license),
+            rights_holder: Some(meta.attribution.rights_holder),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
 }

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -1,6 +1,7 @@
 use crate::errors::Error;
 
 pub mod csv;
+pub mod meta;
 
 
 pub trait OperationLoader {


### PR DESCRIPTION
Adds the ability to import any type of dataset inside an archive. Also supports the CSV file in the archive to be compressed by Brotli. The details about the dataset is determined by a meta.toml file inside the archive