### PR TITLE
Implement specimen logging and updating

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,6 +1,6 @@
 name: Mirror repository to codeberg
 
-on: [push]
+on: [push, delete]
 
 jobs:
   sync-codeberg-mirror:
@@ -9,8 +9,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: yesolutions/mirror-action@master
+      - uses: pixta-dev/repository-mirroring-action@v1
         with:
-          REMOTE: 'ssh://git@codeberg.org/ARGA/arga-oplogger.git'
-          GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_MIRROR_SSH_PRIVATE_KEY }}
-          GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_MIRROR_SSH_KNOWN_HOSTS }}
+          target_repo_url:
+            git@codeberg.org/ARGA/arga-oplogger.git
+          ssh_private_key:
+            ${{ secrets.GIT_MIRROR_SSH_PRIVATE_KEY }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -11,7 +11,6 @@ jobs:
           fetch-depth: 0
       - uses: yesolutions/mirror-action@master
         with:
-          REMOTE: 'ssh://codeberg.org/ARGA/arga-oplogger.git'
+          REMOTE: 'ssh://git@codeberg.org/ARGA/arga-oplogger.git'
           GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_MIRROR_SSH_PRIVATE_KEY }}
           GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_MIRROR_SSH_KNOWN_HOSTS }}
-          GIT_SSH_NO_VERIFY_HOST: "true"

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -14,3 +14,4 @@ jobs:
           REMOTE: 'ssh://codeberg.org/ARGA/arga-oplogger.git'
           GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_MIRROR_SSH_PRIVATE_KEY }}
           GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_MIRROR_SSH_KNOWN_HOSTS }}
+          GIT_SSH_NO_VERIFY_HOST: "true"

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: pixta-dev/repository-mirroring-action@v1
         with:
           target_repo_url:
-            git@codeberg.org/ARGA/arga-oplogger.git
+            ssh://git@codeberg.org/ARGA/arga-oplogger.git
           ssh_private_key:
             ${{ secrets.GIT_MIRROR_SSH_PRIVATE_KEY }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,16 @@
+name: Mirror repository to codeberg
+
+on: [push]
+
+jobs:
+  sync-codeberg-mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: yesolutions/mirror-action@master
+        with:
+          REMOTE: 'ssh://codeberg.org/ARGA/arga-oplogger.git'
+          GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_MIRROR_SSH_PRIVATE_KEY }}
+          GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_MIRROR_SSH_KNOWN_HOSTS }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "uuid",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -2015,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,6 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 [[package]]
 name = "arga-core"
 version = "0.1.0"
-source = "git+https://github.com/ARGA-Genomes/arga-backend.git#44f3c498e17b15e7e0816764cd891df7a74fcb62"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -379,7 +378,6 @@ dependencies = [
 [[package]]
 name = "core-derive"
 version = "0.1.0"
-source = "git+https://github.com/ARGA-Genomes/arga-backend.git#44f3c498e17b15e7e0816764cd891df7a74fcb62"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-arga-core = { git = "https://github.com/ARGA-Genomes/arga-backend.git" }
+# arga-core = { git = "https://github.com/ARGA-Genomes/arga-backend.git" }
+arga-core = { path = "../backend/core" }
 bigdecimal = { version = "0.4.5", features = ["serde"] }
 brotli = "6.0.0"
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/docs/reduction.org
+++ b/docs/reduction.org
@@ -1,0 +1,25 @@
+#+title:  Reducing logs to a full record at a point in time
+#+author: Goran Sterjov
+#+date:   2025-05-13
+
+* Intro
+Once a record has been atomised and added to an operation log we can reconstruct a record at any point in time. To do this we need to 'reduce' the log for an entity into a record. This is a relatively simple process due to the logs effectively being a time-series database, which is to say that the ID is a timestamp allowing us to query for entity logs up to a specific point in time.
+
+* Merge policies
+Once we have a selection of logs we use a CRDT construct to combine the atoms into a final record. Refer to the [[./design.org][design doc]] for technical details about how atoms are merged. The process by which a CRDT handles conflicts we call a 'merge policy'. Right now ARGA only implements and uses one merge policy, the Last-Write-Wins policy.
+
+** Last-Write-Wins (LWW)
+This policy is perhaps the most intuitive and simplest to understand. Whether it's a network split or a later data import the latest version of an atom will always be used when reconstructing a record.
+
+* Data update process
+ARGA has a number operation log tables to better compartmentalise them and improve overall performance. Most data links to a name on the `names` table to aid in discoverability and simpler querying. For this reason you will almost always be loading up a name lookup map via `name_lookup()`.
+
+If a name doesn't exist in a lookup it should be inserted first and then linked to in the reduced record. It doesn't matter if there are issues with the name or spelling mistakes, we attempt to preserve the data as it comes in.
+Once a reduced record is ready and referencing the appropriate data it should be upserted into the reduced tables. For example, the `taxa_logs` operations will be reduced and upserted into the `taxa` table. As such the `taxa` table will always have the latest version of all taxonomy data. Effectively all reduced tables operate as a cache for the 'latest snapshot' of our operation logs.
+
+In short the process is as follows:
+- load a chunk of entity logs by calling an implementation of the `EntityPager` trait.
+- reduce the logs by calling an implementation of the `Reducer` trait.
+- load relevant lookup tables.
+- insert mandatory records that are missing such as `names`.
+- upsert the reduced record

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -12,6 +12,7 @@ use crate::{loggers, upsert_meta, ProgressStream};
 #[derive(Debug)]
 pub enum ImportType {
     Unknown,
+    Names,
     Taxa,
     Publications,
     TaxonomicActs,
@@ -26,6 +27,7 @@ impl From<String> for ImportType {
         use ImportType::*;
 
         match value.as_str() {
+            "names.csv.br" => Names,
             "taxa.csv.br" => Taxa,
             "publications.csv.br" => Publications,
             "taxonomic_acts.csv.br" => TaxonomicActs,
@@ -87,13 +89,15 @@ impl Archive {
 
             match import_type {
                 ImportType::Unknown => info!("Unknown type, skipping"),
-                ImportType::Taxa => loggers::taxa::import(stream, &meta.dataset)?,
-                ImportType::Publications => loggers::publications::import_archive(stream, &meta.dataset)?,
-                ImportType::TaxonomicActs => loggers::taxonomic_acts::import(stream, &meta.dataset)?,
-                ImportType::NomenclaturalActs => loggers::nomenclatural_acts::import_archive(stream, &meta.dataset)?,
+                // ImportType::Names => loggers::names::import_archive(stream)?,
+                // ImportType::Taxa => loggers::taxa::import(stream, &meta.dataset)?,
+                // ImportType::Publications => loggers::publications::import_archive(stream, &meta.dataset)?,
+                // ImportType::TaxonomicActs => loggers::taxonomic_acts::import(stream, &meta.dataset)?,
+                // ImportType::NomenclaturalActs => loggers::nomenclatural_acts::import_archive(stream, &meta.dataset)?,
                 ImportType::Collections => loggers::collections::import_archive(stream, &meta.dataset)?,
-                ImportType::Accessions => todo!(),
+                ImportType::Accessions => {}
                 ImportType::Sequences => todo!(),
+                _ => {}
             }
         }
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -93,11 +93,11 @@ impl Archive {
 
             match import_type {
                 ImportType::Unknown => {}
-                // ImportType::Names => loggers::names::import_archive(stream)?,
-                // ImportType::Taxa => loggers::taxa::import(stream, &meta.dataset)?,
-                // ImportType::Publications => loggers::publications::import_archive(stream, &meta.dataset)?,
-                // ImportType::TaxonomicActs => loggers::taxonomic_acts::import(stream, &meta.dataset)?,
-                // ImportType::NomenclaturalActs => loggers::nomenclatural_acts::import_archive(stream, &meta.dataset)?,
+                ImportType::Names => loggers::names::import_archive(stream)?,
+                ImportType::Taxa => loggers::taxa::import(stream, &meta.dataset)?,
+                ImportType::Publications => loggers::publications::import_archive(stream, &meta.dataset)?,
+                ImportType::TaxonomicActs => loggers::taxonomic_acts::import(stream, &meta.dataset)?,
+                ImportType::NomenclaturalActs => loggers::nomenclatural_acts::import_archive(stream, &meta.dataset)?,
                 ImportType::Organisms => loggers::organisms::import_archive(stream, &meta.dataset)?,
                 ImportType::Collections => loggers::collections::import_archive(stream, &meta.dataset)?,
                 ImportType::Accessions => loggers::accessions::import_archive(stream, &meta.dataset)?,

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -17,6 +17,8 @@ pub enum ImportType {
     Publications,
     TaxonomicActs,
     NomenclaturalActs,
+
+    Organisms,
     Collections,
     Accessions,
     Sequences,
@@ -32,6 +34,8 @@ impl From<String> for ImportType {
             "publications.csv.br" => Publications,
             "taxonomic_acts.csv.br" => TaxonomicActs,
             "nomenclatural_acts.csv.br" => NomenclaturalActs,
+
+            "organisms.csv.br" => Organisms,
             "collections.csv.br" => Collections,
             "accessions.csv.br" => Accessions,
             "sequences.csv.br" => Sequences,
@@ -84,19 +88,21 @@ impl Archive {
             let size = entry.header().size()?;
             let import_type = ImportType::from(path.clone());
 
-            info!(path, size, ?import_type);
-            let stream = ProgressStream::new(entry, size as usize);
+            let message = format!("Atomising {path} ({import_type:?})");
+            let stream = ProgressStream::new(entry, size as usize, &message);
 
             match import_type {
-                ImportType::Unknown => info!("Unknown type, skipping"),
+                ImportType::Unknown => {}
                 // ImportType::Names => loggers::names::import_archive(stream)?,
                 // ImportType::Taxa => loggers::taxa::import(stream, &meta.dataset)?,
                 // ImportType::Publications => loggers::publications::import_archive(stream, &meta.dataset)?,
                 // ImportType::TaxonomicActs => loggers::taxonomic_acts::import(stream, &meta.dataset)?,
                 // ImportType::NomenclaturalActs => loggers::nomenclatural_acts::import_archive(stream, &meta.dataset)?,
+                ImportType::Organisms => loggers::organisms::import_archive(stream, &meta.dataset)?,
                 ImportType::Collections => loggers::collections::import_archive(stream, &meta.dataset)?,
-                ImportType::Accessions => {}
+                ImportType::Accessions => loggers::accessions::import_archive(stream, &meta.dataset)?,
                 ImportType::Sequences => todo!(),
+
                 _ => {}
             }
         }

--- a/src/database.rs
+++ b/src/database.rs
@@ -105,6 +105,7 @@ pub fn create_dataset_version(dataset_id: &str, version: &str, created_at: &str)
     Ok(dataset_version)
 }
 
+
 /// Refreshes a materialized view.
 /// This can be a costly operation depending on the view being refreshed.
 /// Because we cant use bound parameters on this query we instead use an enum to

--- a/src/database.rs
+++ b/src/database.rs
@@ -83,7 +83,7 @@ fn find_dataset_id(dataset_id: &str) -> Result<Uuid, Error> {
 pub fn create_dataset_version(dataset_id: &str, version: &str, created_at: &str) -> Result<DatasetVersion, Error> {
     use schema::dataset_versions;
 
-    info!(dataset_id, version, created_at, "Creating dataset version");
+    // info!(dataset_id, version, created_at, "Creating dataset version");
     let pool = get_pool()?;
     let mut conn = pool.get()?;
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -189,27 +189,6 @@ pub fn name_lookup(pool: &mut PgPool) -> Result<StringMap, Error> {
     Ok(map)
 }
 
-pub fn name_publication_lookup(pool: &mut PgPool) -> Result<StringMap, Error> {
-    use schema::name_publications::dsl::*;
-    info!("Creating name publication map");
-
-    let mut conn = pool.get()?;
-
-    let results = name_publications
-        .select((id, citation))
-        .load::<(Uuid, Option<String>)>(&mut conn)?;
-
-    let mut map = StringMap::new();
-    for (uuid, lookup) in results {
-        if let Some(lookup) = lookup {
-            map.insert(lookup, uuid);
-        }
-    }
-
-    info!(total = map.len(), "Creating name publication map finished");
-    Ok(map)
-}
-
 pub fn publication_lookup(pool: &mut PgPool) -> Result<StringMap, Error> {
     use schema::publications::dsl::*;
     info!("Creating publication map");
@@ -226,41 +205,6 @@ pub fn publication_lookup(pool: &mut PgPool) -> Result<StringMap, Error> {
     info!(total = map.len(), "Creating publication map finished");
     Ok(map)
 }
-
-pub fn organism_lookup(pool: &mut PgPool) -> Result<StringMap, Error> {
-    use schema::organisms::dsl::*;
-    info!("Creating organism map");
-
-    let mut conn = pool.get()?;
-
-    // let results = organisms.select((id, organism_id)).load::<(Uuid, String)>(&mut conn)?;
-
-    let mut map = StringMap::new();
-    // for (uuid, lookup) in results {
-    //     map.insert(lookup, uuid);
-    // }
-
-    info!(total = map.len(), "Creating organism map finished");
-    Ok(map)
-}
-
-pub fn specimen_lookup(pool: &mut PgPool) -> Result<StringMap, Error> {
-    use schema::specimens::dsl::*;
-    info!("Creating specimen map");
-
-    let mut conn = pool.get()?;
-
-    // let results = organisms.select((id, specimen_id)).load::<(Uuid, String)>(&mut conn)?;
-
-    let mut map = StringMap::new();
-    // for (uuid, lookup) in results {
-    //     map.insert(lookup, uuid);
-    // }
-
-    info!(total = map.len(), "Creating specimen map finished");
-    Ok(map)
-}
-
 
 #[derive(Clone)]
 pub struct FrameLoader<T> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -72,6 +72,6 @@ pub enum LookupError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum ReduceError {
-    #[error("The entity is incomplete and missing an required atom: entity_id: {0}, atom: {1}")]
+    #[error("The entity is incomplete and missing a required atom: entity_id: {0}, atom: {1}")]
     MissingAtom(String, String),
 }

--- a/src/loggers/accessions.rs
+++ b/src/loggers/accessions.rs
@@ -2,15 +2,19 @@ use std::io::Read;
 
 use arga_core::crdt::DataFrame;
 use arga_core::models::logs::{AccessionEventAtom, AccessionEventOperation};
-use arga_core::models::DatasetVersion;
-use arga_core::schema;
+use arga_core::models::{self, DatasetVersion};
+use arga_core::{schema, schema_gnl};
 use diesel::*;
 use serde::Deserialize;
+use tracing::error;
+use xxhash_rust::xxh3::xxh3_64;
 
-use crate::database::FrameLoader;
-use crate::errors::Error;
+use crate::database::{name_lookup, FrameLoader, StringMap};
+use crate::errors::*;
 use crate::frames::IntoFrame;
 use crate::readers::{meta, OperationLoader};
+use crate::reducer::{DatabaseReducer, EntityPager, Reducer};
+use crate::utils::new_progress_bar;
 use crate::{frame_push_opt, import_compressed_csv_stream, FrameProgress};
 
 type AccessionEventFrame = DataFrame<AccessionEventAtom>;
@@ -90,20 +94,25 @@ struct Record {
     specimen_id: String,
     scientific_name: String,
 
+    type_status: Option<String>,
     event_date: Option<chrono::NaiveDate>,
     event_time: Option<chrono::NaiveTime>,
-
-    type_status: Option<String>,
 
     collection_repository_id: Option<String>,
     collection_repository_code: Option<String>,
     institution_name: Option<String>,
     institution_code: Option<String>,
-    other_catalog_numbers: Option<String>,
 
-    accessioned_by: Option<String>,
     disposition: Option<String>,
     preparation: Option<String>,
+
+    accessioned_by: Option<String>,
+    prepared_by: Option<String>,
+    identified_by: Option<String>,
+    identified_date: Option<chrono::NaiveDate>,
+    identification_remarks: Option<String>,
+
+    other_catalog_numbers: Option<String>,
 }
 
 impl IntoFrame for Record {
@@ -118,17 +127,21 @@ impl IntoFrame for Record {
 
         frame.push(SpecimenId(self.specimen_id));
         frame.push(ScientificName(self.scientific_name));
+        frame_push_opt!(frame, TypeStatus, self.type_status);
         frame_push_opt!(frame, EventDate, self.event_date);
         frame_push_opt!(frame, EventTime, self.event_time);
-        frame_push_opt!(frame, TypeStatus, self.type_status);
         frame_push_opt!(frame, CollectionRepositoryId, self.collection_repository_id);
         frame_push_opt!(frame, CollectionRepositoryCode, self.collection_repository_code);
         frame_push_opt!(frame, InstitutionName, self.institution_name);
         frame_push_opt!(frame, InstitutionCode, self.institution_code);
-        frame_push_opt!(frame, OtherCatalogNumbers, self.other_catalog_numbers);
-        frame_push_opt!(frame, AccessionedBy, self.accessioned_by);
         frame_push_opt!(frame, Disposition, self.disposition);
         frame_push_opt!(frame, Preparation, self.preparation);
+        frame_push_opt!(frame, AccessionedBy, self.accessioned_by);
+        frame_push_opt!(frame, PreparedBy, self.prepared_by);
+        frame_push_opt!(frame, IdentifiedBy, self.identified_by);
+        frame_push_opt!(frame, IdentifiedDate, self.identified_date);
+        frame_push_opt!(frame, IdentificationRemarks, self.identification_remarks);
+        frame_push_opt!(frame, OtherCatalogNumbers, self.other_catalog_numbers);
         frame
     }
 }
@@ -136,4 +149,200 @@ impl IntoFrame for Record {
 
 pub fn import_archive<S: Read + FrameProgress>(stream: S, dataset: &meta::Dataset) -> Result<(), Error> {
     import_compressed_csv_stream::<S, Record, AccessionEventOperation>(stream, dataset)
+}
+
+
+impl EntityPager for FrameLoader<AccessionEventOperation> {
+    type Operation = models::AccessionEventOperation;
+
+    fn total(&self) -> Result<i64, Error> {
+        let mut conn = self.pool.get()?;
+        let total = schema_gnl::accession_event_entities::table
+            .count()
+            .get_result::<i64>(&mut conn)?;
+        Ok(total)
+    }
+
+    fn load_entity_operations(&self, page: usize) -> Result<Vec<Self::Operation>, Error> {
+        use schema::accession_event_logs::dsl::*;
+        use schema_gnl::accession_event_entities;
+
+        let mut conn = self.pool.get()?;
+
+        let limit = 1000;
+        let offset = page as i64 * limit;
+
+        let entity_ids = accession_event_entities::table
+            .select(accession_event_entities::entity_id)
+            .order_by(accession_event_entities::entity_id)
+            .offset(offset)
+            .limit(limit)
+            .into_boxed();
+
+        let operations = accession_event_logs
+            .filter(entity_id.eq_any(entity_ids))
+            .order_by(operation_id)
+            .load::<AccessionEventOperation>(&mut conn)?;
+
+        Ok(operations)
+    }
+}
+
+
+struct Lookups {
+    names: StringMap,
+}
+
+impl Reducer<Lookups> for models::AccessionEvent {
+    type Atom = AccessionEventAtom;
+
+    fn reduce(entity_id: String, atoms: Vec<Self::Atom>, lookups: &Lookups) -> Result<Self, Error> {
+        use AccessionEventAtom::*;
+
+        let mut specimen_id = None;
+        let mut scientific_name = None;
+        let mut type_status = None;
+        let mut event_date = None;
+        let mut event_time = None;
+        let mut collection_repository_id = None;
+        let mut collection_repository_code = None;
+        let mut institution_name = None;
+        let mut institution_code = None;
+        let mut disposition = None;
+        let mut preparation = None;
+        let mut accessioned_by = None;
+        let mut prepared_by = None;
+        let mut identified_by = None;
+        let mut identified_date = None;
+        let mut identification_remarks = None;
+        let mut other_catalog_numbers = None;
+
+
+        for atom in atoms {
+            match atom {
+                Empty => {}
+                SpecimenId(value) => specimen_id = Some(value),
+                ScientificName(value) => scientific_name = Some(value),
+                TypeStatus(value) => type_status = Some(value),
+                EventDate(value) => event_date = Some(value),
+                EventTime(value) => event_time = Some(value),
+                CollectionRepositoryId(value) => collection_repository_id = Some(value),
+                CollectionRepositoryCode(value) => collection_repository_code = Some(value),
+                InstitutionName(value) => institution_name = Some(value),
+                InstitutionCode(value) => institution_code = Some(value),
+                Disposition(value) => disposition = Some(value),
+                Preparation(value) => preparation = Some(value),
+                AccessionedBy(value) => accessioned_by = Some(value),
+                PreparedBy(value) => prepared_by = Some(value),
+                IdentifiedBy(value) => identified_by = Some(value),
+                IdentifiedDate(value) => identified_date = Some(value),
+                IdentificationRemarks(value) => identification_remarks = Some(value),
+                OtherCatalogNumbers(value) => other_catalog_numbers = Some(value),
+            }
+        }
+
+        // error out if a mandatory atom is not present. without these fields
+        // we cannot construct a reduced record
+        let scientific_name =
+            scientific_name.ok_or(ReduceError::MissingAtom(entity_id.clone(), "ScientificName".to_string()))?;
+        let specimen_id = specimen_id.ok_or(ReduceError::MissingAtom(entity_id.clone(), "SpecimenId".to_string()))?;
+
+        let specimen_entity_id = xxh3_64(specimen_id.as_bytes());
+
+
+        let record = models::AccessionEvent {
+            entity_id,
+            specimen_id: specimen_entity_id.to_string(),
+
+            // everything in our database basically links to a name. we never should get an error
+            // here as all names _should_ be imported with every dataset. however that is outside
+            // the control of the oplogger so if you can't match a name make a loud noise
+            name_id: lookups
+                .names
+                .get(&scientific_name)
+                .ok_or(LookupError::Name(scientific_name))?
+                .clone(),
+
+            type_status,
+            event_date,
+            event_time,
+            collection_repository_id,
+            collection_repository_code,
+            institution_name,
+            institution_code,
+            disposition,
+            preparation,
+            accessioned_by,
+            prepared_by,
+            identified_by,
+            identified_date,
+            identification_remarks,
+            other_catalog_numbers,
+        };
+
+        Ok(record)
+    }
+}
+
+
+pub fn update() -> Result<(), Error> {
+    let mut pool = crate::database::get_pool()?;
+
+    let lookups = Lookups {
+        names: name_lookup(&mut pool)?,
+    };
+
+    let pager: FrameLoader<AccessionEventOperation> = FrameLoader::new(pool.clone());
+    let bar = new_progress_bar(pager.total()? as usize, "Updating accession events");
+
+    let reducer: DatabaseReducer<models::AccessionEvent, _, _> = DatabaseReducer::new(pager, lookups);
+    let mut conn = pool.get()?;
+
+    for records in reducer.into_iter() {
+        for chunk in records.chunks(1000) {
+            use diesel::upsert::excluded;
+            use schema::accession_events::dsl::*;
+
+            let mut valid_records = Vec::new();
+
+            for record in chunk {
+                match record {
+                    Ok(record) => valid_records.push(record),
+                    Err(err) => error!(?err),
+                }
+            }
+
+            // postgres always creates a new row version so we cant get
+            // an actual figure of the amount of records changed
+            diesel::insert_into(accession_events)
+                .values(valid_records)
+                .on_conflict(entity_id)
+                .do_update()
+                .set((
+                    name_id.eq(excluded(name_id)),
+                    specimen_id.eq(excluded(specimen_id)),
+                    type_status.eq(excluded(type_status)),
+                    event_date.eq(excluded(event_date)),
+                    event_time.eq(excluded(event_time)),
+                    collection_repository_id.eq(excluded(collection_repository_id)),
+                    collection_repository_code.eq(excluded(collection_repository_code)),
+                    institution_name.eq(excluded(institution_name)),
+                    institution_code.eq(excluded(institution_code)),
+                    disposition.eq(excluded(disposition)),
+                    preparation.eq(excluded(preparation)),
+                    accessioned_by.eq(excluded(accessioned_by)),
+                    prepared_by.eq(excluded(prepared_by)),
+                    identified_by.eq(excluded(identified_by)),
+                    identified_date.eq(excluded(identified_date)),
+                    identification_remarks.eq(excluded(identification_remarks)),
+                    other_catalog_numbers.eq(excluded(other_catalog_numbers)),
+                ))
+                .execute(&mut conn)?;
+
+            bar.inc(chunk.len() as u64);
+        }
+    }
+
+    bar.finish();
+    Ok(())
 }

--- a/src/loggers/accessions.rs
+++ b/src/loggers/accessions.rs
@@ -1,0 +1,139 @@
+use std::io::Read;
+
+use arga_core::crdt::DataFrame;
+use arga_core::models::logs::{AccessionEventAtom, AccessionEventOperation};
+use arga_core::models::DatasetVersion;
+use arga_core::schema;
+use diesel::*;
+use serde::Deserialize;
+
+use crate::database::FrameLoader;
+use crate::errors::Error;
+use crate::frames::IntoFrame;
+use crate::readers::{meta, OperationLoader};
+use crate::{frame_push_opt, import_compressed_csv_stream, FrameProgress};
+
+type AccessionEventFrame = DataFrame<AccessionEventAtom>;
+
+
+impl OperationLoader for FrameLoader<AccessionEventOperation> {
+    type Operation = AccessionEventOperation;
+
+    fn load_operations(&self, version: &DatasetVersion, entity_ids: &[&String]) -> Result<Vec<Self::Operation>, Error> {
+        use schema::accession_event_logs::dsl::*;
+        use schema::dataset_versions;
+
+        let mut conn = self.pool.get()?;
+
+        // NOTE: there's no good reason to use a UUID for the dataset version, but if we instead
+        // used a hybrid logical clock derived from the meta.toml then it would be trivial to find
+        // all operations that occur <= a certain dataset
+        //
+        // it would still be nice to be able to mark all the operations with a HLC derived from the
+        // the dataset but the problem there is the limited space for the logical component. it would
+        // not be unreasonable to try and import a single dataset with over 5 million records.
+        let ops = accession_event_logs
+            .inner_join(dataset_versions::table.on(dataset_versions::id.eq(dataset_version_id)))
+            .filter(dataset_versions::created_at.le(version.created_at))
+            .filter(entity_id.eq_any(entity_ids))
+            .select(accession_event_logs::all_columns())
+            .order(operation_id.asc())
+            .load::<AccessionEventOperation>(&mut conn)?;
+
+        Ok(ops)
+    }
+
+    fn load_dataset_operations(
+        &self,
+        version: &DatasetVersion,
+        entity_ids: &[&String],
+    ) -> Result<Vec<Self::Operation>, Error> {
+        use schema::accession_event_logs::dsl::*;
+        use schema::dataset_versions;
+
+        let mut conn = self.pool.get()?;
+
+        let ops = accession_event_logs
+            .inner_join(dataset_versions::table.on(dataset_versions::id.eq(dataset_version_id)))
+            .filter(dataset_versions::dataset_id.eq(version.dataset_id))
+            .filter(dataset_versions::created_at.le(version.created_at))
+            .filter(entity_id.eq_any(entity_ids))
+            .select(accession_event_logs::all_columns())
+            .order(operation_id.asc())
+            .load::<AccessionEventOperation>(&mut conn)?;
+
+        Ok(ops)
+    }
+
+    fn upsert_operations(&self, operations: &[AccessionEventOperation]) -> Result<usize, Error> {
+        use schema::accession_event_logs::dsl::*;
+        let mut conn = self.pool.get()?;
+
+        let inserted = diesel::insert_into(accession_event_logs)
+            .values(operations)
+            .execute(&mut conn)
+            .unwrap();
+
+        Ok(inserted)
+    }
+}
+
+
+// A single row in a supported CSV file.
+//
+// For specimens this is conflated with a collection event, so we deserialize both
+// in order to split them up into different operation logs down the line without having
+// to reprocess the CSV file.
+#[derive(Debug, Clone, Deserialize)]
+struct Record {
+    entity_id: String,
+    specimen_id: String,
+    scientific_name: String,
+
+    event_date: Option<chrono::NaiveDate>,
+    event_time: Option<chrono::NaiveTime>,
+
+    type_status: Option<String>,
+
+    collection_repository_id: Option<String>,
+    collection_repository_code: Option<String>,
+    institution_name: Option<String>,
+    institution_code: Option<String>,
+    other_catalog_numbers: Option<String>,
+
+    accessioned_by: Option<String>,
+    disposition: Option<String>,
+    preparation: Option<String>,
+}
+
+impl IntoFrame for Record {
+    type Atom = AccessionEventAtom;
+
+    fn entity_hashable(&self) -> &[u8] {
+        self.entity_id.as_bytes()
+    }
+
+    fn into_frame(self, mut frame: AccessionEventFrame) -> AccessionEventFrame {
+        use AccessionEventAtom::*;
+
+        frame.push(SpecimenId(self.specimen_id));
+        frame.push(ScientificName(self.scientific_name));
+        frame_push_opt!(frame, EventDate, self.event_date);
+        frame_push_opt!(frame, EventTime, self.event_time);
+        frame_push_opt!(frame, TypeStatus, self.type_status);
+        frame_push_opt!(frame, CollectionRepositoryId, self.collection_repository_id);
+        frame_push_opt!(frame, CollectionRepositoryCode, self.collection_repository_code);
+        frame_push_opt!(frame, InstitutionName, self.institution_name);
+        frame_push_opt!(frame, InstitutionCode, self.institution_code);
+        frame_push_opt!(frame, OtherCatalogNumbers, self.other_catalog_numbers);
+        frame_push_opt!(frame, AccessionedBy, self.accessioned_by);
+        frame_push_opt!(frame, Disposition, self.disposition);
+        frame_push_opt!(frame, Preparation, self.preparation);
+        frame
+    }
+}
+
+
+pub fn import_archive<S: Read + FrameProgress>(stream: S, dataset: &meta::Dataset) -> Result<(), Error> {
+    import_compressed_csv_stream::<S, Record, AccessionEventOperation>(stream, dataset)
+}

--- a/src/loggers/collections.rs
+++ b/src/loggers/collections.rs
@@ -2,46 +2,45 @@ use std::io::Read;
 
 use arga_core::crdt::lww::Map;
 use arga_core::crdt::DataFrame;
-use arga_core::models::{self, LogOperation, SpecimenAtom, SpecimenOperation};
-use arga_core::schema;
+use arga_core::models::{self, CollectionEventAtom, CollectionEventOperation};
+use arga_core::{schema, schema_gnl};
 use diesel::*;
-use rayon::prelude::*;
 use serde::Deserialize;
-use tracing::{error, info};
+use tracing::{error, info, trace};
 
-use crate::database::{dataset_lookup, name_lookup, FrameLoader, PgPool, StringMap};
-use crate::errors::Error;
+use crate::database::{name_lookup, organism_lookup, specimen_lookup, FrameLoader, StringMap};
+use crate::errors::{Error, LookupError, ReduceError};
 use crate::frames::IntoFrame;
 use crate::readers::{meta, OperationLoader};
 use crate::reducer::{DatabaseReducer, EntityPager, Reducer};
-use crate::utils::{new_progress_bar, titleize_first_word};
+use crate::utils::new_progress_bar;
 use crate::{frame_push_opt, import_compressed_csv_stream, FrameProgress};
 
-type SpecimenFrame = DataFrame<SpecimenAtom>;
+type CollectionEventFrame = DataFrame<CollectionEventAtom>;
 
 
-impl OperationLoader for FrameLoader<SpecimenOperation> {
-    type Operation = SpecimenOperation;
+impl OperationLoader for FrameLoader<CollectionEventOperation> {
+    type Operation = CollectionEventOperation;
 
-    fn load_operations(&self, entity_ids: &[&String]) -> Result<Vec<SpecimenOperation>, Error> {
-        use schema::specimen_logs::dsl::*;
+    fn load_operations(&self, entity_ids: &[&String]) -> Result<Vec<CollectionEventOperation>, Error> {
+        use schema::collection_event_logs::dsl::*;
         let mut conn = self.pool.get()?;
 
-        let ops = specimen_logs
+        let ops = collection_event_logs
             .filter(entity_id.eq_any(entity_ids))
             .order(operation_id.asc())
-            .load::<SpecimenOperation>(&mut conn)?;
+            .load::<CollectionEventOperation>(&mut conn)?;
 
         Ok(ops)
     }
 
-    fn upsert_operations(&self, operations: &[SpecimenOperation]) -> Result<usize, Error> {
-        use schema::specimen_logs::dsl::*;
+    fn upsert_operations(&self, operations: &[CollectionEventOperation]) -> Result<usize, Error> {
+        use schema::collection_event_logs::dsl::*;
         let mut conn = self.pool.get()?;
 
         // if there is a conflict based on the operation id then it is a duplicate
         // operation so do nothing with it
-        let inserted = diesel::insert_into(specimen_logs)
+        let inserted = diesel::insert_into(collection_event_logs)
             .values(operations)
             .on_conflict_do_nothing()
             .execute(&mut conn)?;
@@ -59,97 +58,113 @@ impl OperationLoader for FrameLoader<SpecimenOperation> {
 #[derive(Debug, Clone, Deserialize)]
 struct Record {
     entity_id: String,
-    record_id: String,
+    field_collecting_id: String,
     scientific_name: String,
-    canonical_name: String,
-    scientific_name_authority: Option<String>,
+    organism_id: String,
+    specimen_id: Option<String>,
 
-    type_status: Option<String>,
-    institution_name: Option<String>,
-    institution_code: Option<String>,
-    // collection_code: Option<String>,
-    // catalog_number: Option<String>,
-    // collected_by: Option<String>,
-    // identified_by: Option<String>,
-    // identified_date: Option<String>,
-    // organism_id: Option<String>,
-    // material_sample_id: Option<String>,
-    // details: Option<String>,
-    // remarks: Option<String>,
-    // identification_remarks: Option<String>,
+    event_date: Option<chrono::NaiveDate>,
+    event_time: Option<chrono::NaiveTime>,
 
-    // // location block
-    // locality: Option<String>,
-    // country: Option<String>,
-    // country_code: Option<String>,
-    // state_province: Option<String>,
-    // county: Option<String>,
-    // municipality: Option<String>,
-    // latitude: Option<f64>,
-    // longitude: Option<f64>,
-    // // verbatim_lat_long: Option<String>,
-    // elevation: Option<f64>,
-    // depth: Option<f64>,
-    // elevation_accuracy: Option<f64>,
-    // depth_accuracy: Option<f64>,
-    // location_source: Option<String>,
+    collected_by: Option<String>,
+    collection_remarks: Option<String>,
 
-    // // collection event block
-    // event_date: Option<String>,
-    // event_time: Option<String>,
-    // field_number: Option<String>,
-    // field_notes: Option<String>,
-    // record_number: Option<String>,
-    // individual_count: Option<String>,
-    // organism_quantity: Option<String>,
-    // organism_quantity_type: Option<String>,
-    // sex: Option<String>,
-    // genotypic_sex: Option<String>,
-    // phenotypic_sex: Option<String>,
-    // life_stage: Option<String>,
-    // reproductive_condition: Option<String>,
-    // behavior: Option<String>,
-    // establishment_means: Option<String>,
-    // degree_of_establishment: Option<String>,
-    // pathway: Option<String>,
-    // occurrence_status: Option<String>,
-    // preparation: Option<String>,
-    // other_catalog_numbers: Option<String>,
-    // env_broad_scale: Option<String>,
-    // env_local_scale: Option<String>,
-    // env_medium: Option<String>,
-    // habitat: Option<String>,
-    // ref_biomaterial: Option<String>,
-    // source_mat_id: Option<String>,
-    // specific_host: Option<String>,
-    // strain: Option<String>,
-    // isolate: Option<String>,
+    identified_by: Option<String>,
+    identified_date: Option<chrono::NaiveDate>,
+    identification_remarks: Option<String>,
+
+    // location block
+    locality: Option<String>,
+    country: Option<String>,
+    country_code: Option<String>,
+    state_province: Option<String>,
+    county: Option<String>,
+    municipality: Option<String>,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+    elevation: Option<f64>,
+    depth: Option<f64>,
+    elevation_accuracy: Option<f64>,
+    depth_accuracy: Option<f64>,
+    location_source: Option<String>,
+
+    preparation: Option<String>,
+    environment_broad_scale: Option<String>,
+    environment_local_scale: Option<String>,
+    environment_medium: Option<String>,
+
+    habitat: Option<String>,
+    specific_host: Option<String>,
+
+    individual_count: Option<String>,
+    organism_quantity: Option<String>,
+    organism_quantity_type: Option<String>,
+
+    strain: Option<String>,
+    isolate: Option<String>,
+    field_notes: Option<String>,
 }
 
 impl IntoFrame for Record {
-    type Atom = SpecimenAtom;
+    type Atom = CollectionEventAtom;
 
     fn entity_hashable(&self) -> &[u8] {
         self.entity_id.as_bytes()
     }
 
-    fn into_frame(self, mut frame: SpecimenFrame) -> SpecimenFrame {
-        use SpecimenAtom::*;
-        frame.push(EntityId(self.entity_id));
-        frame.push(RecordId(self.record_id));
-        frame.push(ScientificName(titleize_first_word(&self.scientific_name)));
-        frame.push(CanonicalName(titleize_first_word(&self.canonical_name)));
-        frame_push_opt!(frame, Authorship, self.scientific_name_authority);
-        frame_push_opt!(frame, TypeStatus, self.type_status);
-        frame_push_opt!(frame, InstitutionName, self.institution_name);
-        frame_push_opt!(frame, InstitutionCode, self.institution_code);
+    fn into_frame(self, mut frame: CollectionEventFrame) -> CollectionEventFrame {
+        use CollectionEventAtom::*;
+
+        // identity
+        frame.push(FieldCollectingId(self.field_collecting_id));
+        frame.push(ScientificName(self.scientific_name));
+        frame.push(OrganismId(self.organism_id));
+        frame_push_opt!(frame, SpecimenId, self.specimen_id);
+
+        // location
+        frame_push_opt!(frame, Locality, self.locality);
+        frame_push_opt!(frame, Country, self.country);
+        frame_push_opt!(frame, CountryCode, self.country_code);
+        frame_push_opt!(frame, StateProvince, self.state_province);
+        frame_push_opt!(frame, County, self.county);
+        frame_push_opt!(frame, Municipality, self.municipality);
+        frame_push_opt!(frame, Latitude, self.latitude);
+        frame_push_opt!(frame, Longitude, self.longitude);
+        frame_push_opt!(frame, Elevation, self.elevation);
+        frame_push_opt!(frame, Depth, self.depth);
+        frame_push_opt!(frame, ElevationAccuracy, self.elevation_accuracy);
+        frame_push_opt!(frame, DepthAccuracy, self.depth_accuracy);
+        frame_push_opt!(frame, LocationSource, self.location_source);
+
+        frame_push_opt!(frame, EventDate, self.event_date);
+        frame_push_opt!(frame, EventTime, self.event_time);
+        frame_push_opt!(frame, CollectedBy, self.collected_by);
+        frame_push_opt!(frame, CollectionRemarks, self.collection_remarks);
+        frame_push_opt!(frame, IdentifiedBy, self.identified_by);
+        frame_push_opt!(frame, IdentifiedDate, self.identified_date);
+        frame_push_opt!(frame, IdentificationRemarks, self.identification_remarks);
+
+        frame_push_opt!(frame, Preparation, self.preparation);
+        frame_push_opt!(frame, EnvironmentBroadScale, self.environment_broad_scale);
+        frame_push_opt!(frame, EnvironmentLocalScale, self.environment_local_scale);
+        frame_push_opt!(frame, EnvironmentMedium, self.environment_medium);
+
+        frame_push_opt!(frame, Habitat, self.habitat);
+        frame_push_opt!(frame, SpecificHost, self.specific_host);
+        frame_push_opt!(frame, IndividualCount, self.individual_count);
+        frame_push_opt!(frame, OrganismQuantity, self.organism_quantity);
+        frame_push_opt!(frame, OrganismQuantityType, self.organism_quantity_type);
+
+        frame_push_opt!(frame, Strain, self.strain);
+        frame_push_opt!(frame, Isolate, self.isolate);
+        frame_push_opt!(frame, FieldNotes, self.field_notes);
         frame
     }
 }
 
 
 pub fn import_archive<S: Read + FrameProgress>(stream: S, dataset: &meta::Dataset) -> Result<(), Error> {
-    import_compressed_csv_stream::<S, Record, SpecimenOperation>(stream, dataset)
+    import_compressed_csv_stream::<S, Record, CollectionEventOperation>(stream, dataset)
 }
 
 
@@ -158,25 +173,26 @@ pub fn update() -> Result<(), Error> {
 
     let lookups = Lookups {
         names: name_lookup(&mut pool)?,
-        datasets: dataset_lookup(&mut pool)?,
+        organisms: organism_lookup(&mut pool)?,
+        specimens: specimen_lookup(&mut pool)?,
     };
 
-    let pager: FrameLoader<SpecimenOperation> = FrameLoader::new(pool.clone());
-    let bar = new_progress_bar(pager.total()? as usize, "Updating specimens");
+    let pager: FrameLoader<CollectionEventOperation> = FrameLoader::new(pool.clone());
+    let bar = new_progress_bar(pager.total()? as usize, "Updating collection events");
 
     // get the total amount of distinct entities in the log table. this allows
     // us to split up the reduction into many threads without loading all operations
     // into memory
     let total_entities = pager.total()?;
-    info!(total_entities, "Reducing specimens");
+    info!(total_entities, "Reducing collection events");
 
-    let reducer: DatabaseReducer<models::Specimen, _, _> = DatabaseReducer::new(pager, lookups);
+    let reducer: DatabaseReducer<models::CollectionEvent, _, _> = DatabaseReducer::new(pager, lookups);
     let mut conn = pool.get()?;
 
     for records in reducer.into_iter() {
         for chunk in records.chunks(1000) {
             use diesel::upsert::excluded;
-            use schema::specimens::dsl::*;
+            use schema::collection_events::dsl::*;
 
             let mut valid_records = Vec::new();
             for record in chunk {
@@ -188,23 +204,20 @@ pub fn update() -> Result<(), Error> {
 
             // postgres always creates a new row version so we cant get
             // an actual figure of the amount of records changed
-            diesel::insert_into(specimens)
+            diesel::insert_into(collection_events)
                 .values(valid_records)
                 .on_conflict(id)
                 .do_update()
                 .set((
-                    entity_id.eq(excluded(entity_id)),
+                    field_collecting_id.eq(excluded(field_collecting_id)),
                     name_id.eq(excluded(name_id)),
-                    record_id.eq(excluded(record_id)),
-                    material_sample_id.eq(excluded(material_sample_id)),
                     organism_id.eq(excluded(organism_id)),
-                    institution_name.eq(excluded(institution_name)),
-                    institution_code.eq(excluded(institution_code)),
-                    collection_code.eq(excluded(collection_code)),
-                    recorded_by.eq(excluded(recorded_by)),
+                    specimen_id.eq(excluded(specimen_id)),
+                    collected_by.eq(excluded(collected_by)),
+                    collection_remarks.eq(excluded(collection_remarks)),
                     identified_by.eq(excluded(identified_by)),
                     identified_date.eq(excluded(identified_date)),
-                    type_status.eq(excluded(type_status)),
+                    identification_remarks.eq(excluded(identification_remarks)),
                     locality.eq(excluded(locality)),
                     country.eq(excluded(country)),
                     country_code.eq(excluded(country_code)),
@@ -218,9 +231,18 @@ pub fn update() -> Result<(), Error> {
                     elevation_accuracy.eq(excluded(elevation_accuracy)),
                     depth_accuracy.eq(excluded(depth_accuracy)),
                     location_source.eq(excluded(location_source)),
-                    details.eq(excluded(details)),
-                    remarks.eq(excluded(remarks)),
-                    identification_remarks.eq(excluded(identification_remarks)),
+                    preparation.eq(excluded(preparation)),
+                    environment_broad_scale.eq(excluded(environment_broad_scale)),
+                    environment_local_scale.eq(excluded(environment_local_scale)),
+                    environment_medium.eq(excluded(environment_medium)),
+                    habitat.eq(excluded(habitat)),
+                    specific_host.eq(excluded(specific_host)),
+                    individual_count.eq(excluded(individual_count)),
+                    organism_quantity.eq(excluded(organism_quantity)),
+                    organism_quantity_type.eq(excluded(organism_quantity_type)),
+                    strain.eq(excluded(strain)),
+                    isolate.eq(excluded(isolate)),
+                    field_notes.eq(excluded(field_notes)),
                 ))
                 .execute(&mut conn)?;
 
@@ -235,29 +257,30 @@ pub fn update() -> Result<(), Error> {
 
 struct Lookups {
     names: StringMap,
-    datasets: StringMap,
+    organisms: StringMap,
+    specimens: StringMap,
 }
 
 
-impl Reducer<Lookups> for models::Specimen {
-    type Atom = SpecimenAtom;
+impl Reducer<Lookups> for models::CollectionEvent {
+    type Atom = CollectionEventAtom;
 
     fn reduce(frame: Map<Self::Atom>, lookups: &Lookups) -> Result<Self, Error> {
-        use SpecimenAtom::*;
+        use CollectionEventAtom::*;
 
-        let mut record_id = None;
-        let mut material_sample_id = None;
+        let mut field_collecting_id = None;
+        let mut specimen_id = None;
         let mut organism_id = None;
         let mut scientific_name = None;
-        let mut canonical_name = None;
-        let mut authorship = None;
-        let mut institution_name = None;
-        let mut institution_code = None;
-        let mut collection_code = None;
-        let mut recorded_by = None;
+
+        let mut event_date = None;
+        let mut event_time = None;
+        let mut collected_by = None;
+        let mut collection_remarks = None;
         let mut identified_by = None;
         let mut identified_date = None;
-        let mut type_status = None;
+        let mut identification_remarks = None;
+
         let mut locality = None;
         let mut country = None;
         let mut country_code = None;
@@ -271,27 +294,36 @@ impl Reducer<Lookups> for models::Specimen {
         let mut elevation_accuracy = None;
         let mut depth_accuracy = None;
         let mut location_source = None;
-        let mut details = None;
-        let mut remarks = None;
-        let mut identification_remarks = None;
+
+        let mut preparation = None;
+        let mut environment_broad_scale = None;
+        let mut environment_local_scale = None;
+        let mut environment_medium = None;
+        let mut habitat = None;
+        let mut specific_host = None;
+        let mut individual_count = None;
+        let mut organism_quantity = None;
+        let mut organism_quantity_type = None;
+        let mut strain = None;
+        let mut isolate = None;
+        let mut field_notes = None;
 
         for atom in frame.atoms.into_values() {
             match atom {
                 Empty => {}
-                EntityId(_) => {}
-                RecordId(value) => record_id = Some(value),
-                MaterialSampleId(value) => material_sample_id = Some(value),
+                FieldCollectingId(value) => field_collecting_id = Some(value),
+                SpecimenId(value) => specimen_id = Some(value),
                 OrganismId(value) => organism_id = Some(value),
                 ScientificName(value) => scientific_name = Some(value),
-                CanonicalName(value) => canonical_name = Some(value),
-                Authorship(value) => authorship = Some(value),
-                InstitutionName(value) => institution_name = Some(value),
-                InstitutionCode(value) => institution_code = Some(value),
-                CollectionCode(value) => collection_code = Some(value),
-                RecordedBy(value) => recorded_by = Some(value),
+
+                EventDate(value) => event_date = Some(value),
+                EventTime(value) => event_time = Some(value),
+                CollectedBy(value) => collected_by = Some(value),
+                CollectionRemarks(value) => collection_remarks = Some(value),
                 IdentifiedBy(value) => identified_by = Some(value),
                 IdentifiedDate(value) => identified_date = Some(value),
-                TypeStatus(value) => type_status = Some(value),
+                IdentificationRemarks(value) => identification_remarks = Some(value),
+
                 Locality(value) => locality = Some(value),
                 Country(value) => country = Some(value),
                 CountryCode(value) => country_code = Some(value),
@@ -305,35 +337,65 @@ impl Reducer<Lookups> for models::Specimen {
                 ElevationAccuracy(value) => elevation_accuracy = Some(value),
                 DepthAccuracy(value) => depth_accuracy = Some(value),
                 LocationSource(value) => location_source = Some(value),
-                Details(value) => details = Some(value),
-                Remarks(value) => remarks = Some(value),
-                IdentificationRemarks(value) => identification_remarks = Some(value),
+
+                Preparation(value) => preparation = Some(value),
+                EnvironmentBroadScale(value) => environment_broad_scale = Some(value),
+                EnvironmentLocalScale(value) => environment_local_scale = Some(value),
+                EnvironmentMedium(value) => environment_medium = Some(value),
+                Habitat(value) => habitat = Some(value),
+                SpecificHost(value) => specific_host = Some(value),
+                IndividualCount(value) => individual_count = Some(value),
+                OrganismQuantity(value) => organism_quantity = Some(value),
+                OrganismQuantityType(value) => organism_quantity_type = Some(value),
+                Strain(value) => strain = Some(value),
+                Isolate(value) => isolate = Some(value),
+                FieldNotes(value) => field_notes = Some(value),
             }
         }
 
-        let record = models::Specimen {
+        // error out if a mandatory atom is not present. without these fields
+        // we cannot construct a reduced record
+        let field_collecting_id = field_collecting_id
+            .ok_or(ReduceError::MissingAtom(frame.entity_id.to_string(), "FieldCollectingId".to_string()))?;
+        let scientific_name = scientific_name
+            .ok_or(ReduceError::MissingAtom(frame.entity_id.to_string(), "ScientificName".to_string()))?;
+        let organism_id =
+            organism_id.ok_or(ReduceError::MissingAtom(frame.entity_id.to_string(), "OrganismId".to_string()))?;
+
+
+        let record = models::CollectionEvent {
             id: uuid::Uuid::new_v4(),
-            entity_id: Some(frame.entity_id),
-            dataset_id: lookups
-                .datasets
-                .get("ARGA:TL:0001000")
-                .expect("dataset not found")
-                .clone(),
+            entity_id: frame.entity_id,
+            field_collecting_id,
+
+            // everything in our database basically links to a name. we never should get an error
+            // here as all names _should_ be imported with every dataset. however that is outside
+            // the control of the oplogger so if you can't match a name make a loud noise
             name_id: lookups
                 .names
-                .get(&scientific_name.expect("scientific_name not found"))
-                .expect("name not found")
+                .get(&scientific_name)
+                .ok_or(LookupError::Name(scientific_name))?
                 .clone(),
-            record_id: record_id.expect("record_id not found"),
-            material_sample_id,
-            organism_id,
-            institution_name,
-            institution_code,
-            collection_code,
-            recorded_by,
+
+            // every collection must have an organism. we will stub it out if the dataset doesn't
+            // actually include any organism data
+            organism_id: lookups
+                .organisms
+                .get(&organism_id)
+                .ok_or(LookupError::Name(organism_id))?
+                .clone(),
+
+            // we can have collected specimens before they get registered into an official repository
+            // so if we don't find a specimen then leave it as null
+            specimen_id: specimen_id.and_then(|id| lookups.specimens.get(&id).copied()),
+
+            event_date,
+            event_time,
+            collected_by,
+            collection_remarks,
             identified_by,
             identified_date,
-            type_status,
+            identification_remarks,
             locality,
             country,
             country_code,
@@ -347,9 +409,20 @@ impl Reducer<Lookups> for models::Specimen {
             elevation_accuracy,
             depth_accuracy,
             location_source,
-            details,
-            remarks,
-            identification_remarks,
+
+            preparation,
+            environment_broad_scale,
+            environment_local_scale,
+            environment_medium,
+            habitat,
+            specific_host,
+            individual_count,
+            organism_quantity,
+            organism_quantity_type,
+
+            strain,
+            isolate,
+            field_notes,
         };
 
         Ok(record)
@@ -357,43 +430,41 @@ impl Reducer<Lookups> for models::Specimen {
 }
 
 
-impl EntityPager for FrameLoader<SpecimenOperation> {
-    type Operation = models::SpecimenOperation;
+impl EntityPager for FrameLoader<CollectionEventOperation> {
+    type Operation = models::CollectionEventOperation;
 
     fn total(&self) -> Result<i64, Error> {
         let mut conn = self.pool.get()?;
-
-        let total = {
-            use diesel::dsl::count_distinct;
-            use schema::specimen_logs::dsl::*;
-            specimen_logs
-                .select(count_distinct(entity_id))
-                .get_result::<i64>(&mut conn)?
-        };
+        let total = schema_gnl::collection_event_entities::table
+            .count()
+            .get_result::<i64>(&mut conn)?;
 
         Ok(total)
     }
 
     fn load_entity_operations(&self, page: usize) -> Result<Vec<Self::Operation>, Error> {
-        use schema::specimen_logs::dsl::*;
+        trace!(page, "loading entity operations");
+
+        use schema::collection_event_logs::dsl::*;
+        use schema_gnl::collection_event_entities;
+
         let mut conn = self.pool.get()?;
 
-        let limit = 10_000;
+        let limit = 1000;
         let offset = page as i64 * limit;
 
-        let entity_ids = specimen_logs
-            .select(entity_id)
-            .group_by(entity_id)
-            .order_by(entity_id)
+        let entity_ids = collection_event_entities::table
+            .select(collection_event_entities::entity_id)
             .offset(offset)
             .limit(limit)
             .into_boxed();
 
-        let operations = specimen_logs
+        let operations = collection_event_logs
             .filter(entity_id.eq_any(entity_ids))
-            .order_by((entity_id, operation_id))
-            .load::<SpecimenOperation>(&mut conn)?;
+            .order_by(operation_id)
+            .load::<CollectionEventOperation>(&mut conn)?;
 
+        trace!(total = operations.len(), "operations loaded");
         Ok(operations)
     }
 }

--- a/src/loggers/mod.rs
+++ b/src/loggers/mod.rs
@@ -1,7 +1,9 @@
+pub mod accessions;
 pub mod collections;
 pub mod datasets;
 pub mod names;
 pub mod nomenclatural_acts;
+pub mod organisms;
 pub mod publications;
 pub mod sequences;
 pub mod sources;
@@ -15,8 +17,9 @@ use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 
 use arga_core::crdt::{DataFrame, DataFrameOperation};
-use arga_core::models::{self, LogOperation};
-use arga_core::schema;
+use arga_core::models::logs::LogOperation;
+use arga_core::models::DatasetVersion;
+use arga_core::{models, schema};
 use diesel::*;
 use indicatif::ProgressBarIter;
 use rayon::prelude::*;
@@ -26,7 +29,7 @@ use uuid::Uuid;
 use crate::database::{create_dataset_version, get_pool, FrameLoader, PgPool};
 use crate::errors::Error;
 use crate::frames::{FrameReader, Framer, IntoFrame};
-use crate::operations::distinct_changes;
+use crate::operations::{distinct_changes, distinct_dataset_changes};
 use crate::readers::csv::CsvReader;
 use crate::readers::{meta, OperationLoader};
 use crate::utils::FrameImportBars;
@@ -49,8 +52,8 @@ pub struct ProgressStream<S: Read> {
 }
 
 impl<S: Read> ProgressStream<S> {
-    pub fn new(stream: S, total_bytes: usize) -> ProgressStream<S> {
-        let bars = FrameImportBars::new(total_bytes);
+    pub fn new(stream: S, total_bytes: usize, message: &str) -> ProgressStream<S> {
+        let bars = FrameImportBars::new(total_bytes, message);
         let stream = bars.bytes.wrap_read(stream);
         ProgressStream { stream, bars }
     }
@@ -82,15 +85,15 @@ pub fn import_csv_as_logs<T, Op>(path: &PathBuf, dataset_version_id: &Uuid) -> R
 where
     Op: Sync,
     T: DeserializeOwned + IntoFrame,
-    T::Atom: Default + Clone + ToString + PartialEq,
+    T::Atom: Default + Clone + ToString + PartialEq + std::fmt::Debug,
     FrameLoader<Op>: OperationLoader + Clone,
     <FrameLoader<Op> as OperationLoader>::Operation:
-        LogOperation<T::Atom> + From<DataFrameOperation<T::Atom>> + Clone + Sync,
+        LogOperation<T::Atom> + From<DataFrameOperation<T::Atom>> + Clone + Sync + std::fmt::Debug,
 {
     let file = File::open(path)?;
     let size = file.metadata()?.size();
-    let stream = ProgressStream::new(file, size as usize);
-    import_csv_from_stream::<T, Op, _>(stream, dataset_version_id)?;
+    let stream = ProgressStream::new(file, size as usize, "Importing");
+    // import_csv_from_stream::<T, Op, _>(stream, dataset_version_id)?;
     Ok(())
 }
 
@@ -104,14 +107,14 @@ where
     S: Read + FrameProgress,
     Op: Sync,
     T: DeserializeOwned + IntoFrame,
-    T::Atom: Default + Clone + ToString + PartialEq,
+    T::Atom: Default + Clone + ToString + PartialEq + std::fmt::Debug,
     FrameLoader<Op>: OperationLoader + Clone,
     <FrameLoader<Op> as OperationLoader>::Operation:
-        LogOperation<T::Atom> + From<DataFrameOperation<T::Atom>> + Clone + Sync,
+        LogOperation<T::Atom> + From<DataFrameOperation<T::Atom>> + Clone + Sync + std::fmt::Debug,
 {
     let input = brotli::Decompressor::new(stream, 4096);
     let dataset_version = create_dataset_version(&dataset.id, &dataset.version, &dataset.published_at.to_string())?;
-    import_csv_from_stream::<T, Op, _>(input, &dataset_version.id)?;
+    import_csv_from_stream::<T, Op, _>(input, &dataset_version)?;
     Ok(())
 }
 
@@ -125,15 +128,15 @@ where
 /// The Record (<T>) must implement the IntoFrame trait and be deserializable from a CSV file.
 /// The Operation (<Op>) must implement the OperationLoader trait
 /// The Reader (<R>) only needs to implement std::io::Read
-pub fn import_csv_from_stream<T, Op, R>(reader: R, dataset_version_id: &Uuid) -> Result<(), Error>
+pub fn import_csv_from_stream<T, Op, R>(reader: R, dataset_version: &DatasetVersion) -> Result<(), Error>
 where
     R: Read + FrameProgress,
     Op: Sync,
     T: DeserializeOwned + IntoFrame,
-    T::Atom: Default + Clone + ToString + PartialEq,
+    T::Atom: Default + Clone + ToString + PartialEq + std::fmt::Debug,
     FrameLoader<Op>: OperationLoader + Clone,
     <FrameLoader<Op> as OperationLoader>::Operation:
-        LogOperation<T::Atom> + From<DataFrameOperation<T::Atom>> + Clone + Sync,
+        LogOperation<T::Atom> + From<DataFrameOperation<T::Atom>> + Clone + Sync + std::fmt::Debug,
 {
     let bars = reader.bars();
 
@@ -142,7 +145,7 @@ where
     // us to conveniently get chunks of frames from the reader and sets us up for easy parallelization.
     // and the third is the frame loader which allows us to query the database to deduplicate and
     // pull out unique operations, as well as upsert the new operations.
-    let reader = CsvReader::<T, R>::from_reader(reader, *dataset_version_id)?;
+    let reader = CsvReader::<T, R>::from_reader(reader, dataset_version.id.clone())?;
     let framer = Framer::new(reader);
     let loader = FrameLoader::<Op>::new(get_pool()?);
 
@@ -159,8 +162,16 @@ where
         frames.operations()?.par_chunks(10_000).try_for_each(|slice| {
             let total = slice.len();
 
-            // compare the ops with previously imported ops and only return actual changes
-            let changes = distinct_changes(slice.to_vec(), &loader)?;
+            // compare the ops with previously imported ops and only return actual changes for the
+            // specific dataset being imported. this is effectively the changeset between dataset versions
+            let dataset_changes = distinct_dataset_changes(&dataset_version, slice.to_vec(), &loader)?;
+
+            // now compare the dataset changes with the fully reduced entity. this allows us to only
+            // keep changes that occur across datasets instead of keeping full changelog versions of
+            // all datasets that get imported. importantly we compare against a fully reduced entity
+            // *at a specific point in time*, in our case the publication date of the dataset version.
+            // without it we would overwrite data changed by newer dataset versions
+            let changes = distinct_changes(&dataset_version, dataset_changes, &loader)?;
             let inserted = loader.upsert_operations(&changes)?;
 
             bars.inserted.inc(inserted as u64);
@@ -188,12 +199,12 @@ where
 pub fn import_frames_from_stream<Op, R>(reader: R, pool: PgPool) -> Result<(), Error>
 where
     R: FrameReader + FrameProgress,
-    R::Atom: Default + Clone + ToString + PartialEq,
+    R::Atom: Default + Clone + ToString + PartialEq + std::fmt::Debug,
     R: Iterator<Item = Result<DataFrame<R::Atom>, Error>>,
     Op: Sync,
     FrameLoader<Op>: OperationLoader + Clone,
     <FrameLoader<Op> as OperationLoader>::Operation:
-        LogOperation<R::Atom> + From<DataFrameOperation<R::Atom>> + Clone + Sync,
+        LogOperation<R::Atom> + From<DataFrameOperation<R::Atom>> + Clone + Sync + std::fmt::Debug,
 {
     let bars = reader.bars();
 
@@ -215,17 +226,17 @@ where
         // we flatten out all the frames into operations and process them in chunks of 10k.
         // postgres has a parameter limit and by chunking it we can query the database to
         // filter to distinct changes and import it in bulk without triggering any errors.
-        frames.operations()?.par_chunks(10_000).try_for_each(|slice| {
-            let total = slice.len();
+        // frames.operations()?.par_chunks(10_000).try_for_each(|slice| {
+        //     let total = slice.len();
 
-            // compare the ops with previously imported ops and only return actual changes
-            let changes = distinct_changes(slice.to_vec(), &loader)?;
-            let inserted = loader.upsert_operations(&changes)?;
+        //     // compare the ops with previously imported ops and only return actual changes
+        //     let changes = distinct_changes(slice.to_vec(), &loader)?;
+        //     let inserted = loader.upsert_operations(&changes)?;
 
-            bars.inserted.inc(inserted as u64);
-            bars.operations.inc(total as u64);
-            Ok::<(), Error>(())
-        })?;
+        //     bars.inserted.inc(inserted as u64);
+        //     bars.operations.inc(total as u64);
+        //     Ok::<(), Error>(())
+        // })?;
 
         bars.frames.inc(total_frames as u64);
     }

--- a/src/loggers/mod.rs
+++ b/src/loggers/mod.rs
@@ -19,11 +19,8 @@ use arga_core::models::{self, LogOperation};
 use arga_core::schema;
 use diesel::*;
 use indicatif::ProgressBarIter;
-pub use nomenclatural_acts::NomenclaturalActs;
 use rayon::prelude::*;
-pub use sequences::Sequences;
 use serde::de::DeserializeOwned;
-pub use taxonomic_acts::TaxonomicActs;
 use uuid::Uuid;
 
 use crate::database::{create_dataset_version, get_pool, FrameLoader, PgPool};

--- a/src/loggers/names.rs
+++ b/src/loggers/names.rs
@@ -7,7 +7,6 @@ use tracing::info;
 
 use crate::database::PgPool;
 use crate::errors::Error;
-use crate::readers::meta;
 use crate::utils::new_progress_bar;
 use crate::FrameProgress;
 
@@ -62,7 +61,7 @@ pub fn import_archive<S: Read + FrameProgress>(stream: S) -> Result<(), Error> {
 
     for row in reader.deserialize::<Record>().into_iter() {
         let record = row?;
-        bars.frames.inc(1);
+        // bars.frames.inc(1);
 
         names.push(models::Name {
             id: uuid::Uuid::new_v4(),

--- a/src/loggers/names.rs
+++ b/src/loggers/names.rs
@@ -1,10 +1,27 @@
+use std::io::Read;
+
 use arga_core::{models, schema};
 use diesel::*;
+use serde::Deserialize;
 use tracing::info;
 
 use crate::database::PgPool;
 use crate::errors::Error;
+use crate::readers::meta;
 use crate::utils::new_progress_bar;
+use crate::FrameProgress;
+
+
+/// The CSV name record to import directly.
+/// This is deserializeable with the serde crate and enforces expectations
+/// about what fields are mandatory and the format they should be in.
+#[derive(Debug, Clone, Deserialize, Default)]
+struct Record {
+    pub scientific_name: String,
+    pub scientific_authorship: Option<String>,
+    pub canonical_name: String,
+}
+
 
 /// Import names if they are not already in the table. This is an upsert and will
 /// update the data if it matches on scientific name
@@ -32,4 +49,34 @@ pub fn import(pool: PgPool, records: &[models::Name]) -> Result<(), Error> {
     bar.finish();
     info!(total = records.len(), total_imported, "Name import finished");
     Ok(())
+}
+
+
+pub fn import_archive<S: Read + FrameProgress>(stream: S) -> Result<(), Error> {
+    let bars = stream.bars();
+
+    let input = brotli::Decompressor::new(stream, 4096);
+    let mut reader = csv::Reader::from_reader(input);
+
+    let mut names = Vec::new();
+
+    for row in reader.deserialize::<Record>().into_iter() {
+        let record = row?;
+        bars.frames.inc(1);
+
+        names.push(models::Name {
+            id: uuid::Uuid::new_v4(),
+            scientific_name: record.scientific_name,
+            canonical_name: record.canonical_name,
+            authorship: record.scientific_authorship,
+        })
+    }
+    bars.finish();
+
+    // sort and dedup names otherwise we will hit on conflict errors in postres
+    names.sort_by(|a, b| a.scientific_name.cmp(&b.scientific_name));
+    names.dedup_by(|a, b| a.scientific_name.eq(&b.scientific_name));
+
+    let pool = crate::database::get_pool()?;
+    import(pool, &names)
 }

--- a/src/loggers/organisms.rs
+++ b/src/loggers/organisms.rs
@@ -1,0 +1,118 @@
+use std::io::Read;
+
+use arga_core::crdt::DataFrame;
+use arga_core::models::{DatasetVersion, OrganismAtom, OrganismOperation};
+use arga_core::schema;
+use diesel::*;
+use serde::Deserialize;
+
+use crate::database::FrameLoader;
+use crate::errors::Error;
+use crate::frames::IntoFrame;
+use crate::readers::{meta, OperationLoader};
+use crate::{frame_push_opt, import_compressed_csv_stream, FrameProgress};
+
+type OrganismFrame = DataFrame<OrganismAtom>;
+
+
+impl OperationLoader for FrameLoader<OrganismOperation> {
+    type Operation = OrganismOperation;
+
+    fn load_operations(&self, version: &DatasetVersion, entity_ids: &[&String]) -> Result<Vec<Self::Operation>, Error> {
+        use schema::dataset_versions;
+        use schema::organism_logs::dsl::*;
+
+        let mut conn = self.pool.get()?;
+
+        let ops = organism_logs
+            .inner_join(dataset_versions::table.on(dataset_versions::id.eq(dataset_version_id)))
+            .filter(dataset_versions::created_at.le(version.created_at))
+            .filter(entity_id.eq_any(entity_ids))
+            .select(organism_logs::all_columns())
+            .order(operation_id.asc())
+            .load::<OrganismOperation>(&mut conn)?;
+
+        Ok(ops)
+    }
+
+    fn load_dataset_operations(
+        &self,
+        version: &DatasetVersion,
+        entity_ids: &[&String],
+    ) -> Result<Vec<Self::Operation>, Error> {
+        use schema::dataset_versions;
+        use schema::organism_logs::dsl::*;
+
+        let mut conn = self.pool.get()?;
+
+        let ops = organism_logs
+            .inner_join(dataset_versions::table.on(dataset_versions::id.eq(dataset_version_id)))
+            .filter(dataset_versions::dataset_id.eq(version.dataset_id))
+            .filter(dataset_versions::created_at.le(version.created_at))
+            .filter(entity_id.eq_any(entity_ids))
+            .select(organism_logs::all_columns())
+            .order(operation_id.asc())
+            .load::<OrganismOperation>(&mut conn)?;
+
+        Ok(ops)
+    }
+
+    fn upsert_operations(&self, operations: &[OrganismOperation]) -> Result<usize, Error> {
+        use schema::organism_logs::dsl::*;
+        let mut conn = self.pool.get()?;
+
+        let inserted = diesel::insert_into(organism_logs)
+            .values(operations)
+            .execute(&mut conn)
+            .unwrap();
+
+        Ok(inserted)
+    }
+}
+
+
+// A single row in a supported CSV file.
+//
+// For specimens this is conflated with a collection event, so we deserialize both
+// in order to split them up into different operation logs down the line without having
+// to reprocess the CSV file.
+#[derive(Debug, Clone, Deserialize)]
+struct Record {
+    entity_id: String,
+    scientific_name: String,
+    organism_id: String,
+
+    sex: Option<String>,
+    genotypic_sex: Option<String>,
+    phenotypic_sex: Option<String>,
+    life_stage: Option<String>,
+    reproductive_condition: Option<String>,
+    behavior: Option<String>,
+}
+
+impl IntoFrame for Record {
+    type Atom = OrganismAtom;
+
+    fn entity_hashable(&self) -> &[u8] {
+        self.entity_id.as_bytes()
+    }
+
+    fn into_frame(self, mut frame: OrganismFrame) -> OrganismFrame {
+        use OrganismAtom::*;
+
+        frame.push(OrganismId(self.organism_id));
+        frame.push(ScientificName(self.scientific_name));
+        frame_push_opt!(frame, Sex, self.sex);
+        frame_push_opt!(frame, GenotypicSex, self.genotypic_sex);
+        frame_push_opt!(frame, PhenotypicSex, self.phenotypic_sex);
+        frame_push_opt!(frame, LifeStage, self.life_stage);
+        frame_push_opt!(frame, ReproductiveCondition, self.reproductive_condition);
+        frame_push_opt!(frame, Behavior, self.behavior);
+        frame
+    }
+}
+
+
+pub fn import_archive<S: Read + FrameProgress>(stream: S, dataset: &meta::Dataset) -> Result<(), Error> {
+    import_compressed_csv_stream::<S, Record, OrganismOperation>(stream, dataset)
+}

--- a/src/loggers/organisms.rs
+++ b/src/loggers/organisms.rs
@@ -1,15 +1,18 @@
 use std::io::Read;
 
 use arga_core::crdt::DataFrame;
-use arga_core::models::{DatasetVersion, OrganismAtom, OrganismOperation};
-use arga_core::schema;
+use arga_core::models::{self, DatasetVersion, OrganismAtom, OrganismOperation};
+use arga_core::{schema, schema_gnl};
 use diesel::*;
 use serde::Deserialize;
+use tracing::error;
 
-use crate::database::FrameLoader;
-use crate::errors::Error;
+use crate::database::{name_lookup, FrameLoader, StringMap};
+use crate::errors::*;
 use crate::frames::IntoFrame;
 use crate::readers::{meta, OperationLoader};
+use crate::reducer::{DatabaseReducer, EntityPager, Reducer};
+use crate::utils::new_progress_bar;
 use crate::{frame_push_opt, import_compressed_csv_stream, FrameProgress};
 
 type OrganismFrame = DataFrame<OrganismAtom>;
@@ -115,4 +118,160 @@ impl IntoFrame for Record {
 
 pub fn import_archive<S: Read + FrameProgress>(stream: S, dataset: &meta::Dataset) -> Result<(), Error> {
     import_compressed_csv_stream::<S, Record, OrganismOperation>(stream, dataset)
+}
+
+
+impl EntityPager for FrameLoader<OrganismOperation> {
+    type Operation = models::OrganismOperation;
+
+    fn total(&self) -> Result<i64, Error> {
+        let mut conn = self.pool.get()?;
+        let total = schema_gnl::organism_entities::table
+            .count()
+            .get_result::<i64>(&mut conn)?;
+        Ok(total)
+    }
+
+    fn load_entity_operations(&self, page: usize) -> Result<Vec<Self::Operation>, Error> {
+        use schema::organism_logs::dsl::*;
+        use schema_gnl::organism_entities;
+
+        let mut conn = self.pool.get()?;
+
+        let limit = 1000;
+        let offset = page as i64 * limit;
+
+        let entity_ids = organism_entities::table
+            .select(organism_entities::entity_id)
+            .order_by(organism_entities::entity_id)
+            .offset(offset)
+            .limit(limit)
+            .into_boxed();
+
+        let operations = organism_logs
+            .filter(entity_id.eq_any(entity_ids))
+            .order_by(operation_id)
+            .load::<OrganismOperation>(&mut conn)?;
+
+        Ok(operations)
+    }
+}
+
+
+struct Lookups {
+    names: StringMap,
+}
+
+impl Reducer<Lookups> for models::Organism {
+    type Atom = OrganismAtom;
+
+    fn reduce(entity_id: String, atoms: Vec<Self::Atom>, lookups: &Lookups) -> Result<Self, Error> {
+        use OrganismAtom::*;
+
+        let mut organism_id = None;
+        let mut scientific_name = None;
+        let mut sex = None;
+        let mut genotypic_sex = None;
+        let mut phenotypic_sex = None;
+        let mut life_stage = None;
+        let mut reproductive_condition = None;
+        let mut behavior = None;
+
+        for atom in atoms {
+            match atom {
+                Empty => {}
+                OrganismId(value) => organism_id = Some(value),
+                ScientificName(value) => scientific_name = Some(value),
+                Sex(value) => sex = Some(value),
+                GenotypicSex(value) => genotypic_sex = Some(value),
+                PhenotypicSex(value) => phenotypic_sex = Some(value),
+                LifeStage(value) => life_stage = Some(value),
+                ReproductiveCondition(value) => reproductive_condition = Some(value),
+                Behavior(value) => behavior = Some(value),
+            }
+        }
+
+        // error out if a mandatory atom is not present. without these fields
+        // we cannot construct a reduced record
+        let scientific_name =
+            scientific_name.ok_or(ReduceError::MissingAtom(entity_id.clone(), "ScientificName".to_string()))?;
+        let organism_id = organism_id.ok_or(ReduceError::MissingAtom(entity_id.clone(), "OrganismId".to_string()))?;
+
+        let record = models::Organism {
+            entity_id,
+
+            // everything in our database basically links to a name. we never should get an error
+            // here as all names _should_ be imported with every dataset. however that is outside
+            // the control of the oplogger so if you can't match a name make a loud noise
+            name_id: lookups
+                .names
+                .get(&scientific_name)
+                .ok_or(LookupError::Name(scientific_name))?
+                .clone(),
+
+            organism_id,
+            sex,
+            genotypic_sex,
+            phenotypic_sex,
+            life_stage,
+            reproductive_condition,
+            behavior,
+        };
+
+        Ok(record)
+    }
+}
+
+
+pub fn update() -> Result<(), Error> {
+    let mut pool = crate::database::get_pool()?;
+
+    let lookups = Lookups {
+        names: name_lookup(&mut pool)?,
+    };
+
+    let pager: FrameLoader<OrganismOperation> = FrameLoader::new(pool.clone());
+    let bar = new_progress_bar(pager.total()? as usize, "Updating organisms");
+
+    let reducer: DatabaseReducer<models::Organism, _, _> = DatabaseReducer::new(pager, lookups);
+    let mut conn = pool.get()?;
+
+    for records in reducer.into_iter() {
+        for chunk in records.chunks(1000) {
+            use diesel::upsert::excluded;
+            use schema::organisms::dsl::*;
+
+            let mut valid_records = Vec::new();
+            for record in chunk {
+                match record {
+                    Ok(record) => valid_records.push(record),
+                    Err(err) => error!(?err),
+                }
+            }
+
+            // postgres always creates a new row version so we cant get
+            // an actual figure of the amount of records changed
+            diesel::insert_into(organisms)
+                .values(valid_records)
+                .on_conflict(entity_id)
+                .do_update()
+                .set((
+                    name_id.eq(excluded(name_id)),
+                    organism_id.eq(excluded(organism_id)),
+                    sex.eq(excluded(sex)),
+                    genotypic_sex.eq(excluded(genotypic_sex)),
+                    phenotypic_sex.eq(excluded(phenotypic_sex)),
+                    life_stage.eq(excluded(life_stage)),
+                    reproductive_condition.eq(excluded(reproductive_condition)),
+                    behavior.eq(excluded(behavior)),
+                ))
+                .execute(&mut conn)?;
+
+            bar.inc(chunk.len() as u64);
+        }
+    }
+
+    bar.finish();
+
+    Ok(())
 }

--- a/src/loggers/sources.rs
+++ b/src/loggers/sources.rs
@@ -1,17 +1,14 @@
 use std::path::PathBuf;
 
-use arga_core::models::AccessRightsStatus;
-use arga_core::models::DataReuseStatus;
-use arga_core::models::Source;
-use arga_core::models::SourceContentType;
+use arga_core::models::{AccessRightsStatus, DataReuseStatus, Source, SourceContentType};
 use arga_core::schema::sources;
 use diesel::*;
+use serde::Deserialize;
+use uuid::Uuid;
 
 use crate::database::get_pool;
 use crate::errors::Error;
 use crate::utils::{access_pill_status_from_str, content_type_from_str, data_reuse_status_from_str};
-use serde::Deserialize;
-use uuid::Uuid;
 
 pub struct Sources {
     pub path: PathBuf,
@@ -49,6 +46,7 @@ impl From<CSVRecord> for Source {
             reuse_pill: value.reuse_pill,
             access_pill: value.access_pill,
             content_type: value.content_type,
+            lists_id: None,
         }
     }
 }

--- a/src/loggers/taxa.rs
+++ b/src/loggers/taxa.rs
@@ -727,14 +727,14 @@ struct LinkLookups {
 impl Reducer<LinkLookups> for TaxonLink {
     type Atom = TaxonAtom;
 
-    fn reduce(frame: Map<Self::Atom>, lookups: &LinkLookups) -> Result<Self, Error> {
+    fn reduce(entity_id: String, atoms: Vec<Self::Atom>, lookups: &LinkLookups) -> Result<Self, Error> {
         use TaxonAtom::*;
 
         let mut dataset_id = None;
         let mut parent_taxon = None;
         let mut scientific_name = None;
 
-        for atom in frame.atoms.into_values() {
+        for atom in atoms {
             match atom {
                 DatasetId(value) => dataset_id = Some(value),
                 ParentTaxon(value) => parent_taxon = Some(value),
@@ -743,8 +743,7 @@ impl Reducer<LinkLookups> for TaxonLink {
             }
         }
 
-        let dataset_id =
-            dataset_id.ok_or(ReduceError::MissingAtom(frame.entity_id.clone(), "DatasetId".to_string()))?;
+        let dataset_id = dataset_id.ok_or(ReduceError::MissingAtom(entity_id.clone(), "DatasetId".to_string()))?;
         let dataset_id = lookups
             .datasets
             .get(&dataset_id)
@@ -752,7 +751,7 @@ impl Reducer<LinkLookups> for TaxonLink {
             .clone();
 
         let scientific_name =
-            scientific_name.ok_or(ReduceError::MissingAtom(frame.entity_id.clone(), "ScientificName".to_string()))?;
+            scientific_name.ok_or(ReduceError::MissingAtom(entity_id.clone(), "ScientificName".to_string()))?;
         let name_id = lookups
             .names
             .get(&scientific_name)
@@ -793,7 +792,7 @@ impl Reducer<LinkLookups> for TaxonLink {
 impl Reducer<Lookups> for models::Taxon {
     type Atom = TaxonAtom;
 
-    fn reduce(frame: Map<Self::Atom>, lookups: &Lookups) -> Result<Self, Error> {
+    fn reduce(entity_id: String, atoms: Vec<Self::Atom>, lookups: &Lookups) -> Result<Self, Error> {
         use TaxonAtom::*;
 
         let mut dataset_id = None;
@@ -809,7 +808,7 @@ impl Reducer<Lookups> for models::Taxon {
         let mut references = None;
         let mut last_updated = None;
 
-        for atom in frame.atoms.into_values() {
+        for atom in atoms {
             match atom {
                 Empty => {}
                 DatasetId(value) => dataset_id = Some(value),
@@ -841,8 +840,7 @@ impl Reducer<Lookups> for models::Taxon {
             }
         }
 
-        let dataset_id =
-            dataset_id.ok_or(ReduceError::MissingAtom(frame.entity_id.clone(), "DatasetId".to_string()))?;
+        let dataset_id = dataset_id.ok_or(ReduceError::MissingAtom(entity_id.clone(), "DatasetId".to_string()))?;
         let dataset_id = lookups
             .datasets
             .get(&dataset_id)
@@ -850,7 +848,7 @@ impl Reducer<Lookups> for models::Taxon {
 
         let record = models::Taxon {
             id: uuid::Uuid::new_v4(),
-            entity_id: Some(frame.entity_id),
+            entity_id: Some(entity_id),
             dataset_id: dataset_id.clone(),
             parent_id: None,
             status: taxonomic_status.expect("taxonomic status not found"),

--- a/src/loggers/taxa.rs
+++ b/src/loggers/taxa.rs
@@ -639,17 +639,17 @@ pub fn link() -> Result<(), Error> {
 
     // we cant do a bulk update without resorting to upserts so instead
     // we use rayon to parallelize to greatly increase the speed
-    links
-        .par_iter()
-        .progress_with(parent_bar)
-        .for_each_init(get_conn, |conn, (taxon_uuid, parent_uuid)| {
-            use schema::taxa::dsl::*;
+    // links
+    //     .par_iter()
+    //     .progress_with(parent_bar)
+    //     .for_each_init(get_conn, |conn, (taxon_uuid, parent_uuid)| {
+    //         use schema::taxa::dsl::*;
 
-            diesel::update(taxa.filter(id.eq(taxon_uuid)))
-                .set(parent_id.eq(parent_uuid))
-                .execute(conn)
-                .expect("Failed to update");
-        });
+    //         diesel::update(taxa.filter(id.eq(taxon_uuid)))
+    //             .set(parent_id.eq(parent_uuid))
+    //             .execute(conn)
+    //             .expect("Failed to update");
+    //     });
 
 
     let mut conn = pool.get()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,8 +108,12 @@ pub enum UpdateCommand {
     NomenclaturalActs,
     /// Update publications with the reduced logs
     Publications,
+    /// Update organisms with the reduced logs
+    Organisms,
     /// Update collections with the reduced logs
     Collections,
+    /// Update accessions with the reduced logs
+    Accessions,
 }
 
 #[derive(clap::Subcommand)]
@@ -208,7 +212,9 @@ fn main() -> Result<(), Error> {
             UpdateCommand::TaxonomicActs => taxonomic_acts::update()?,
             UpdateCommand::NomenclaturalActs => NomenclaturalActs::update()?,
             UpdateCommand::Publications => publications::update()?,
+            UpdateCommand::Organisms => organisms::update()?,
             UpdateCommand::Collections => collections::update()?,
+            UpdateCommand::Accessions => accessions::update()?,
         },
 
         Commands::Link(cmd) => match cmd {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,13 @@ use std::path::PathBuf;
 
 use clap::{Args, Parser};
 use database::create_dataset_version;
+use diesel::connection::set_default_instrumentation;
 use errors::Error;
 use loggers::*;
+use nomenclatural_acts::NomenclaturalActs;
 use readers::plazi;
+use sequences::Sequences;
+use taxonomic_acts::TaxonomicActs;
 
 use crate::datasets::Datasets;
 use crate::sources::Sources;
@@ -126,6 +130,8 @@ fn main() -> Result<(), Error> {
     dotenvy::dotenv().ok();
     tracing_subscriber::fmt::init();
 
+    set_default_instrumentation(database::simple_logger).expect("Failed to setup database instrumentation");
+
     let cli = Cli::parse();
 
     match &cli.command {
@@ -135,7 +141,7 @@ fn main() -> Result<(), Error> {
         }
         Commands::ImportFile(cmd) => match cmd {
             ImportCommand::Taxa(args) => {
-                let dataset_version = create_dataset_version(&args.dataset_id, &args.version, &args.created_at)?;
+                // let dataset_version = create_dataset_version(&args.dataset_id, &args.version, &args.created_at)?;
                 // let taxa = Taxa {
                 //     path: args.path.clone(),
                 //     dataset_version_id: dataset_version.id,

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,12 +1,83 @@
 use std::collections::HashMap;
 
-use arga_core::crdt::lww::Map;
 use arga_core::crdt::DataFrameOperation;
-use arga_core::models::LogOperation;
+use arga_core::models::logs::LogOperation;
+use arga_core::models::DatasetVersion;
 use bigdecimal::BigDecimal;
 
 use crate::errors::Error;
 use crate::readers::OperationLoader;
+
+
+struct CausalOperation<Op, A>
+where
+    A: ToString,
+    Op: LogOperation<A>,
+{
+    index: usize,
+    operation: Op,
+    atom_marker: std::marker::PhantomData<A>,
+}
+
+impl<Op, A> ToString for CausalOperation<Op, A>
+where
+    A: ToString,
+    Op: LogOperation<A>,
+{
+    fn to_string(&self) -> String {
+        format!("{}-{}-{}", self.operation.entity_id(), self.index, self.operation.atom().to_string())
+    }
+}
+
+/// Combine the existing and new operations and group them up by entity id
+pub fn group_causal_operations<T, A>(
+    existing_ops: Vec<T>,
+    new_ops: Vec<T>,
+) -> HashMap<String, Vec<CausalOperation<T, A>>>
+where
+    A: ToString,
+    T: LogOperation<A>,
+{
+    let mut grouped: HashMap<String, Vec<CausalOperation<T, A>>> = HashMap::new();
+
+    let mut existing_counter: HashMap<String, usize> = HashMap::new();
+    for op in existing_ops.into_iter() {
+        let entity_id = op.entity_id().clone();
+
+        let index = *existing_counter
+            .entry(op.atom().to_string())
+            .and_modify(|counter| *counter += 1)
+            .or_insert(0);
+
+        let causal = CausalOperation {
+            index,
+            operation: op,
+            atom_marker: std::marker::PhantomData,
+        };
+
+        grouped.entry(entity_id).or_default().push(causal);
+    }
+
+    let mut new_counter: HashMap<String, usize> = HashMap::new();
+    for op in new_ops.into_iter() {
+        let entity_id = op.entity_id().clone();
+
+        let index = *new_counter
+            .entry(op.atom().to_string())
+            .and_modify(|counter| *counter += 1)
+            .or_insert(0);
+
+        let causal = CausalOperation {
+            index,
+            operation: op,
+            atom_marker: std::marker::PhantomData,
+        };
+
+        grouped.entry(entity_id).or_default().push(causal);
+    }
+
+    grouped
+}
 
 
 /// Combine the existing and new operations and group them up by entity id
@@ -27,6 +98,7 @@ where
     grouped
 }
 
+
 /// Pick out and combine the operations that don't already exist in the existing set of operations.
 ///
 /// This will merge the two lists of operations and use the last-write-wins CRDT map to filter
@@ -36,14 +108,39 @@ where
 /// operation id is different.
 pub fn merge_operations<T, A>(existing_ops: Vec<T>, new_ops: Vec<T>) -> Vec<T>
 where
-    A: ToString + Clone + PartialEq,
-    T: LogOperation<A> + Clone,
+    A: ToString + Clone + PartialEq + std::fmt::Debug,
+    T: LogOperation<A> + Clone + std::fmt::Debug,
 {
     let entities = group_operations(existing_ops, new_ops);
+    // let entities = group_causal_operations(existing_ops, new_ops);
     let mut merged: Vec<T> = Vec::new();
 
+    // get all operations for a specific entity. both existing and new operations.
     for (key, ops) in entities.into_iter() {
-        let mut map = Map::new(key);
+        // let mut fields: HashMap<String, Vec<&T>> = HashMap::new();
+
+        // for op in &ops {
+        //     println!("{key}: {} {:?} -- {}", op.operation.id(), op.operation.atom(), op.to_string());
+
+        //     let field_name = op.operation.atom().to_string();
+
+        //     fields
+        //         .entry(field_name)
+        //         .and_modify(|arr| {
+        //             if arr.last().map(|o| o.atom()) != Some(&op.operation.atom()) {
+        //                 arr.push(&op.operation)
+        //             }
+        //         })
+        //         .or_insert(vec![&op.operation]);
+        // }
+
+        // println!("{:#?}", fields);
+
+        // for arr in fields.into_values() {
+        //     merged.extend(arr.into_iter().map(|r| r.to_owned()));
+        // }
+
+        let mut map = arga_core::crdt::lww::Map::new(key);
         let reduced = map.reduce(&ops);
         merged.extend(reduced.into_iter().map(|r| r.to_owned()));
     }
@@ -62,11 +159,15 @@ where
 ///
 /// Because this uses the loader its best to find an ideal chunk size for the operations vector
 /// so that it can load the operations in bulk while staying within memory and database bounds.
-pub fn distinct_changes<A, L>(ops: Vec<L::Operation>, loader: &L) -> Result<Vec<L::Operation>, Error>
+pub fn distinct_changes<A, L>(
+    version: &DatasetVersion,
+    ops: Vec<L::Operation>,
+    loader: &L,
+) -> Result<Vec<L::Operation>, Error>
 where
-    A: ToString + Clone + PartialEq,
+    A: ToString + Clone + PartialEq + std::fmt::Debug,
     L: OperationLoader,
-    L::Operation: LogOperation<A> + From<DataFrameOperation<A>> + Clone,
+    L::Operation: LogOperation<A> + From<DataFrameOperation<A>> + Clone + std::fmt::Debug,
 {
     // grab all the entity ids in the chunk because we need to check for existing
     // operations in the database for the operation merge
@@ -74,7 +175,53 @@ where
 
     // load the existing operations by looking for the entity ids present in the frame chunk
     // this allows us to group and compare operations in bulk without using all the memory
-    match loader.load_operations(&entity_ids) {
+    match loader.load_operations(&version, &entity_ids) {
+        Err(err) => Err(err),
+        Ok(existing_ops) => {
+            // use these ids to remove it from the merged operation list as they will end up
+            // being no ops. we have to clone the id since they're moved in the merge
+            let ids: Vec<BigDecimal> = existing_ops.iter().map(|op| op.id().clone()).collect();
+
+            // merging ensures that we dont have duplicate ops and that we don't have
+            // *useless* ops, which will helpfully eliminate any operation with a newer
+            // timestamp that doesn't change the actual atom
+            let merged = merge_operations(existing_ops, ops);
+
+            // because merging uses the last-write-wins map for reduction it still returns
+            // the existing operations. since this is a distinct operation iterator we
+            // want to remove the existing ops from the merged set
+            let changes: Vec<L::Operation> = merged.into_iter().filter(|op| !ids.contains(op.id())).collect();
+            Ok(changes)
+        }
+    }
+}
+
+/// Filters out any no-op operations.
+///
+/// This will query the database for existing operations related to the entity ids found
+/// in the `ops` vector and merge them. The merging process uses the LWW policy to determine
+/// which changes are made. It will also filter out the operations already found in the database
+/// which means this will *only* return operations that actually make a change to the entity.
+///
+/// Because this uses the loader its best to find an ideal chunk size for the operations vector
+/// so that it can load the operations in bulk while staying within memory and database bounds.
+pub fn distinct_dataset_changes<A, L>(
+    version: &DatasetVersion,
+    ops: Vec<L::Operation>,
+    loader: &L,
+) -> Result<Vec<L::Operation>, Error>
+where
+    A: ToString + Clone + PartialEq + std::fmt::Debug,
+    L: OperationLoader,
+    L::Operation: LogOperation<A> + From<DataFrameOperation<A>> + Clone + std::fmt::Debug,
+{
+    // grab all the entity ids in the chunk because we need to check for existing
+    // operations in the database for the operation merge
+    let entity_ids: Vec<&String> = ops.iter().map(|op| op.entity_id()).collect();
+
+    // load the existing operations by looking for the entity ids present in the frame chunk
+    // this allows us to group and compare operations in bulk without using all the memory
+    match loader.load_dataset_operations(version, &entity_ids) {
         Err(err) => Err(err),
         Ok(existing_ops) => {
             // use these ids to remove it from the merged operation list as they will end up

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -40,14 +40,15 @@ where
     T: LogOperation<A> + Clone,
 {
     let entities = group_operations(existing_ops, new_ops);
-    let mut merged = Vec::new();
+    let mut merged: Vec<T> = Vec::new();
 
     for (key, ops) in entities.into_iter() {
         let mut map = Map::new(key);
         let reduced = map.reduce(&ops);
-        merged.extend(reduced);
+        merged.extend(reduced.into_iter().map(|r| r.to_owned()));
     }
 
+    merged.sort_by(|a, b| a.id().cmp(b.id()));
     merged
 }
 
@@ -86,9 +87,9 @@ where
             let merged = merge_operations(existing_ops, ops);
 
             // because merging uses the last-write-wins map for reduction it still returns
-            // the existing operations. because this is a distinct operation iterator we
+            // the existing operations. since this is a distinct operation iterator we
             // want to remove the existing ops from the merged set
-            let changes = merged.into_iter().filter(|op| !ids.contains(op.id())).collect();
+            let changes: Vec<L::Operation> = merged.into_iter().filter(|op| !ids.contains(op.id())).collect();
             Ok(changes)
         }
     }

--- a/src/readers/csv.rs
+++ b/src/readers/csv.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use arga_core::crdt::{DataFrame, Version};
 use serde::de::DeserializeOwned;
 use uuid::Uuid;
-use xxhash_rust::xxh3::Xxh3;
+use xxhash_rust::xxh3::xxh3_64;
 
 use crate::errors::Error;
 use crate::frames::{FrameReader, IntoFrame};
@@ -54,9 +54,7 @@ where
             Some(Err(err)) => Some(Err(err.into())),
             Some(Ok(record)) => {
                 // We hash the entity_id to save on storage in the column
-                let mut hasher = Xxh3::new();
-                hasher.update(record.entity_hashable());
-                let hash = hasher.digest().to_string();
+                let hash = xxh3_64(record.entity_hashable()).to_string();
 
                 let frame = DataFrame::create(hash, self.dataset_version_id, self.last_version);
                 let frame = record.into_frame(frame);

--- a/src/readers/csv.rs
+++ b/src/readers/csv.rs
@@ -21,7 +21,7 @@ where
 /// A reader that parses a CSV file and decomposes the row into operation logs.
 ///
 /// This uses mmap and rayon to parallelize the read for performance. This means
-/// that the order of rows are not guarantee and a frame of operation logs should
+/// that the order of rows are not guaranteed and a frame of operation logs should
 /// be contained in one row, with each frame considered a separate transaction and
 /// thus a separate 'change' entry.
 pub struct CsvReader<T, R: Read> {

--- a/src/readers/meta.rs
+++ b/src/readers/meta.rs
@@ -58,6 +58,7 @@ impl From<Meta> for models::Source {
             reuse_pill: None,
             access_pill: None,
             content_type: None,
+            lists_id: None,
         }
     }
 }

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -1,3 +1,5 @@
+use arga_core::models::DatasetVersion;
+
 use crate::errors::Error;
 
 pub mod csv;
@@ -7,6 +9,13 @@ pub mod plazi;
 
 pub trait OperationLoader {
     type Operation;
-    fn load_operations(&self, entity_ids: &[&String]) -> Result<Vec<Self::Operation>, Error>;
+    fn load_operations(&self, version: &DatasetVersion, entity_ids: &[&String]) -> Result<Vec<Self::Operation>, Error>;
+
+    fn load_dataset_operations(
+        &self,
+        version: &DatasetVersion,
+        entity_ids: &[&String],
+    ) -> Result<Vec<Self::Operation>, Error>;
+
     fn upsert_operations(&self, operations: &[Self::Operation]) -> Result<usize, Error>;
 }

--- a/src/readers/plazi/document.rs
+++ b/src/readers/plazi/document.rs
@@ -111,7 +111,7 @@ where
         let mut reader = Reader::from_reader(reader);
         reader.config_mut().trim_text(true);
 
-        let bars = FrameImportBars::new(0);
+        let bars = FrameImportBars::new(0, "Importing");
         let header = Self::parse_header(&mut reader)?;
 
         Ok(DocumentReader {

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -10,7 +10,7 @@ where
 {
     type Atom: Clone + ToString + PartialEq;
 
-    fn reduce(frame: Map<Self::Atom>, lookups: &L) -> Result<Self, Error>;
+    fn reduce(entity_id: String, atoms: Vec<Self::Atom>, lookups: &L) -> Result<Self, Error>;
 }
 
 
@@ -54,9 +54,10 @@ where
 
         // create an LWW map for each entity and reduce it
         for (key, ops) in entities.into_iter() {
-            let mut map = Map::new(key);
-            map.reduce(&ops);
-            let record = R::reduce(map, &self.lookups);
+            let mut map = Map::new(key.clone());
+            let reduced = map.reduce(&ops).into_iter().map(|op| op.atom().to_owned()).collect();
+
+            let record = R::reduce(key, reduced, &self.lookups);
             records.push(record);
         }
 

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -1,7 +1,6 @@
 use arga_core::crdt::lww::Map;
-use arga_core::models::LogOperation;
+use arga_core::models::logs::LogOperation;
 
-use crate::database::PgPool;
 use crate::errors::Error;
 
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -36,7 +36,6 @@ pub fn new_spinner(message: &str) -> ProgressBar {
         .with_message(message.to_string())
         .with_style(style);
 
-    spinner.enable_steady_tick(Duration::from_millis(100));
     spinner
 }
 
@@ -60,7 +59,6 @@ pub fn new_spinner_totals(message: &str) -> ProgressBar {
         .with_message(message.to_string())
         .with_style(style);
 
-    spinner.enable_steady_tick(Duration::from_millis(100));
     spinner
 }
 
@@ -74,9 +72,9 @@ pub struct FrameImportBars {
 }
 
 impl FrameImportBars {
-    pub fn new(total_bytes: usize) -> FrameImportBars {
+    pub fn new(total_bytes: usize, message: &str) -> FrameImportBars {
         let bars = MultiProgress::new();
-        let bytes = new_progress_bar_bytes(total_bytes, "Importing");
+        let bytes = new_progress_bar_bytes(total_bytes, message);
         let operations = new_spinner_totals("Total operations");
         let inserted = new_spinner_totals("Operations inserted");
         let frames = new_spinner_totals("Frames read");
@@ -85,7 +83,13 @@ impl FrameImportBars {
         bars.add(inserted.clone());
         bars.add(frames.clone());
 
+        // because we want the render target to be with the multiprogress we
+        // have to set the tick after adding it otherwise it'll corrupt the screen
+        // by rendering before getting the new target
         bytes.enable_steady_tick(Duration::from_millis(200));
+        operations.enable_steady_tick(Duration::from_millis(200));
+        inserted.enable_steady_tick(Duration::from_millis(200));
+        frames.enable_steady_tick(Duration::from_millis(200));
 
         FrameImportBars {
             _bars: bars,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,6 +29,7 @@ macro_rules! frame_push_opt {
     };
 }
 
+
 pub fn new_spinner(message: &str) -> ProgressBar {
     let style = ProgressStyle::with_template(SPINNER_TEMPLATE).expect("Invalid spinner template");
     let spinner = ProgressBar::new_spinner()


### PR DESCRIPTION
This includes tasks that atomise and log organisms, collections, and accessions. All part of the 'specimen' umbrella. It also updates and links specimens as needed.

Also included is a new way to diff existing logs to get distinct changes by leveraging an entity view to better paginate during the update process, which should make things much more performant